### PR TITLE
Get highcharts to use localtime for x-axis rather than UTC time

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "convert-units": "^2.3.4",
     "highcharts": "^6.1.4",
     "moment": "^2.22.2",
+    "moment-timezone": "^0.5.23",
     "ol": "^5.2.0",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",

--- a/src/components/Charts/LargeTimeSeries.tsx
+++ b/src/components/Charts/LargeTimeSeries.tsx
@@ -32,6 +32,13 @@ function pointFormatMaker(unit: string) {
 }
 
 
+const plotOptions = {
+    time: {
+    	useUTC: false
+    }
+}
+
+
 interface Props {
     /** Time series data to dispaly */
     timeSeries: ReadingTimeSeries[]
@@ -68,7 +75,7 @@ class LargeTimeSeriesChartBase extends React.Component<Props, object> {
         }
 
         return (
-            <HighchartsChart>
+            <HighchartsChart time={plotOptions.time}>
                 <Chart />
 
                 <XAxis type="datetime" />

--- a/src/components/Charts/MultipleLargeTimeSeries.tsx
+++ b/src/components/Charts/MultipleLargeTimeSeries.tsx
@@ -31,6 +31,12 @@ function formatterWrapper(unit) {
     }
 }
 
+const plotOptions = {
+    time: {
+    	useUTC: false
+    }
+}
+
 
 interface Props {
     /** Time series data to display */
@@ -61,7 +67,7 @@ class MultipleLargeTimeSeriesChartBase extends React.Component<Props, object> {
         })
 
         return (
-            <HighchartsChart>
+            <HighchartsChart time={plotOptions.time}>
                 <Chart />
 
                 <XAxis type="datetime" />

--- a/src/components/Charts/SmallTimeSeries.tsx
+++ b/src/components/Charts/SmallTimeSeries.tsx
@@ -30,6 +30,13 @@ function pointFormatMaker(unit: string) {
     }
 }
 
+const plotOptions = {
+    time: {
+    	useUTC: false
+    }
+}
+
+
 
 interface Props {
     /** Time series to display */
@@ -67,7 +74,7 @@ class SmallTimeSeriesChartBase extends React.Component<Props, object> {
         }
 
         return (
-            <HighchartsChart>
+            <HighchartsChart time={plotOptions.time}>
                 <Chart height={150}/>
 
                 <XAxis type='datetime' />

--- a/src/components/Charts/WindTimeSeries.tsx
+++ b/src/components/Charts/WindTimeSeries.tsx
@@ -40,6 +40,12 @@ function pointFormatter(this: any) {
 }
 
 
+const plotOptions = {
+    time: {
+    	useUTC: false
+    }
+}
+
 interface Props {
     /** Wind data to display */
     data: DataTimeSeries[]
@@ -140,7 +146,7 @@ export class WindTimeSeriesChartBase extends React.Component<Props, object> {
         }
 
         return (
-            <HighchartsChart>
+            <HighchartsChart time={plotOptions.time}>
                 <Chart height={this.props.height} />
 
                 <XAxis type='datetime' />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,10 +4,18 @@
 
 import * as Sentry from '@sentry/browser'
 import { ConnectedRouter } from 'connected-react-router'
+
+import moment from 'moment-timezone'
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux'
 // import { HashRouter } from 'react-router-dom'
+
+declare global {
+  interface Window { moment: any }
+}
+
+window.moment = moment
 
 /**
  * Load our package.json so that we can access the version

--- a/yarn.lock
+++ b/yarn.lock
@@ -5682,7 +5682,13 @@ mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@2.22.2, moment@^2.22.2:
+moment-timezone@^0.5.23:
+  version "0.5.23"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.23.tgz#7cbb00db2c14c71b19303cb47b0fb0a6d8651463"
+  dependencies:
+    moment ">= 2.9.0"
+
+moment@2.22.2, "moment@>= 2.9.0", moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 


### PR DESCRIPTION
Added moment.js to allow Highcharts to use localtime rather than UTC time for chart display.