### PR TITLE
Add Kubernetes Deployment Configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ UserInterfaceState.xcuserstate
 *.ipynb
 docs
 build
+docker-hub-secret.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Additions:
 
+- Migrate deployment to Kubernetes using Kustomize and Skaffold.
+
 Changes:
 
 Fixes:

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,22 @@
+FROM node:12.3.1-alpine@sha256:6bed93a9950db2dc1517b6a87e76e6ba842316e440d2ed028302726f723b67be AS buildstep
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+
+RUN apk add --no-cache git
+
+COPY ./package.json /usr/src/app/package.json
+COPY ./yarn.lock /usr/src/app/yarn.lock
+
+RUN yarn install --ignore-optional
+
+COPY . /usr/src/app
+
+RUN yarn build
+
+FROM nginx:alpine@sha256:385fbcf0f04621981df6c6f1abd896101eb61a439746ee2921b26abc78f45571
+
+COPY --from=buildstep /usr/src/app/build /usr/share/nginx/html
+
+COPY ./nginx.production.conf /etc/nginx/conf.d/default.conf

--- a/Makefile
+++ b/Makefile
@@ -9,30 +9,12 @@ up: down
 down:
 	docker-compose down
 
-build: down
-	docker-compose build
-	docker-compose run client yarn build
-
-deploy:
-	scp -r ./build/* awsgmri:/home2/ionic/neracoos1/www/
-	sentry-cli releases -o gulf-of-maine-research-institu deploys $(shell python3 -c "import json; print(json.load(open('package.json'))['version'])") new -e staging
-
-serve-build:
-	python3 -m http.server -d build/
-
-sentry:
-	sentry-cli releases -o gulf-of-maine-research-institu -p neracoos-mariners-dashboard new $(shell python3 -c "import json; print(json.load(open('package.json'))['version'])") --finalize
-	# sentry-cli releases -o gulf-of-maine-research-institu -p neracoos-mariners-dashboard set-commits $(shell python3 -c "import json; print(json.load(open('package.json'))['version'])") --auto
-	sentry-cli releases -o gulf-of-maine-research-institu -p neracoos-mariners-dashboard files $(shell python3 -c "import json; print(json.load(open('package.json'))['version'])") upload-sourcemaps build
-
 prune:
 	docker volume rm $(shell docker volume ls -qf dangling=true)
 	docker system prune -a
 
 patch:
 	npm version patch
-
-release-patch: test down patch build sentry deploy
 
 rm-docs:
 	rm -r docs/ || true

--- a/Readme.md
+++ b/Readme.md
@@ -13,20 +13,22 @@ You can run `make serve-build` to view the build locally before deploying.
 
 ## Deploying and Versioning
 
-The site is currently deployed to http://neracoos.org/ionic/neracoos1/www/index.html
+The site is deployed to the NERACOOS Digital Ocean Kubernetes Cluster.
 
-To update the deployment run `make deploy`.
-You probably want to `npm version patch` (or `minor`/`major` depending on changes) run it in the form
-`make down build deploy sentry` to make sure that you get a production
-build and that there is no iterferance with the local test server and get source maps copied to sentry.
+When you're using the NERACOOS Kubernetes config, to update the deployment run `skaffold run -t VERSION_NUMBER --tail`.
+You probably want to `npm version patch` (or `minor`/`major` depending on changes) first.
 
-The deploy uses `scp` so you will need to have a `~/.ssh/config entry that looks something like this:
+You will need to have `docker-hub-secret.yaml` in `/k8s/` for the deploy to work using an account with access to the GMRI Docker Hub repos.
 
-```sh
-Host awsgmri
-    HostName awsgmri.neracoos.org
-    User great_user_name
-    IdentityFile ~/.ssh/id_rsa
+```yaml
+apiVersion: v1
+data:
+  .dockerconfigjson: Some string
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: docker-hub-secret
+type: kubernetes.io/dockerconfigjson
 ```
 
 ## Generating Pages and Components

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariners-dashboard
+spec:
+  selector:
+    matchLabels:
+      app: mariners-dashboard
+  template:
+    metadata:
+      labels:
+        app: mariners-dashboard
+    spec:
+      containers:
+      - name: mariners-dashboard
+        image: gmri/neracoos-mariners-dashboard
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+        ports:
+        - containerPort: 80
+          name: http
+      imagePullSecrets:
+        - name: docker-hub-secret 

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: mariners-dashboard
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+    - host: mariners.neracoos.org
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: mariners-dashboard
+              servicePort: 80

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,11 @@
+namespace: mariners-dashboard
+resources:
+- docker-hub-secret.yaml
+- frontend.yaml
+- service.yaml
+- ingress.yaml
+commonLabels:
+  app: mariners-dashboard
+  maintainer: akerney
+  funder: NERACOOS
+  project: Mariners_dashboard

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariners-dashboard
+spec:
+  selector:
+    app: mariners-dashboard
+  ports:
+  - port: 80
+    targetPort: 80

--- a/nginx.production.conf
+++ b/nginx.production.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name localhost mariners.neracoos.org;
+    
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri /index.html;
+    }
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,11 @@
+apiVersion: skaffold/v1beta7
+kind: Config
+build:
+  artifacts:
+    - image: gmri/neracoos-mariners-dashboard
+      context: .
+      docker:
+        dockerfile: Dockerfile.production
+deploy:
+  kustomize:
+      path: k8s/


### PR DESCRIPTION
Add deployment configuration and information to get Mariners Dashboard running on the NERACOOS Digital Ocean cluster (instead of AWSGMRI).