### PR TITLE
Fix the sorting of dates in the observation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Fixes:
 
 - Issue with compass points very close to North (~355).
 - Check for feature existance before changing URL.
+- Observation table sorting dates as strings rather than natively.
 
 ## 0.3.3 - Hidden in fog - 9/5/19
 

--- a/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
@@ -9,7 +9,7 @@ import { itemStyle, TableItem } from "./item"
 
 export const ErddapAllObservationsTable: React.SFC<RenderProps> = ({ platform }: RenderProps) => {
   const times = platform.properties.readings.filter(d => d.time !== null).map(d => new Date(d.time as string))
-  times.sort()
+  times.sort((a, b) => a.valueOf() - b.valueOf())
 
   const datasets = platform.properties.readings
 

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -13,7 +13,7 @@ import { itemStyle, TableItem } from "./item"
  */
 export const ErddapObservationTable: React.SFC<RenderProps> = ({ platform }) => {
   const times = platform.properties.readings.filter(d => d.time !== null).map(d => new Date(d.time as string))
-  times.sort()
+  times.sort((a, b) => a.valueOf() - b.valueOf())
 
   return (
     <ListGroup style={{ paddingTop: "1rem" }}>


### PR DESCRIPTION
Previously the observation table was using a naive JavaScript sort which converts elements into strings before sorting. This corrects the sorting to sort by the date values instead.