### PR TITLE
Replace logo with new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Additions:
 Changes:
 
 - Github actions workflow
+- Replace with new NERACOOS logo
 
 Fixes:
 

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -34,7 +34,7 @@ export default class NeracoosNavBar extends React.Component<object, State> {
       <div>
         <Navbar dark={true} expand="md">
           <NavbarBrand tag={Link} to={paths.home}>
-            <img src="http://www.neracoos.org/sites/all/themes/bootstrap_neracoos/logo.png" alt="NERACOOS" />
+            <img src="http://www.neracoos.org/sites/neracoos.org/files/NERACOOS_logo_white_300x43.png" alt="NERACOOS" />
           </NavbarBrand>
           <NavbarToggler onClick={this.toggle} />
 


### PR DESCRIPTION
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/1296209/74541698-1cd4ca80-4f10-11ea-91aa-33c0e3cd9e92.png">

NERACOOS has a new logo, so now the Mariner's Dashboard does too.

[ClickUp Task](https://app.clickup.com/t/44cz15)