### PR TITLE
Add yarn build step to github action tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Typecheck
         run: docker-compose run client yarn types
 
+      - name: Yarn Build
+        run: docker-compose run client yarn build
+
   cypress:
     name: Cypress integration tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a yarn build step to tests. 

Usually the server is launched behind the scenes for Cypress tests, so some errors aren't caught. This should fail on those errors.