### PR TITLE
Change/multiple data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Additions:
 
 Changes:
 
-- Remove signal flags
+- Remove signal flags.
+- Allow multiple data types to be specified in current conditions table and show only the first one matched.
 
 Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ Changes:
 
 - Remove signal flags.
 - Allow multiple data types to be specified in current conditions table and show only the first one matched.
+- Show only one of a group of data types in the current (latest) conditions view.
 
 Fixes:
+
+- A little extra breathing space withing the footer.
 
 ## 0.4.1 - 5/31/2020
 

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.stories.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { select } from "@storybook/addon-knobs"
+
+import { DataCard } from "./data_card"
+import { UnitSystem } from "Features/Units/types"
+
+import { platform } from "stories/platform"
+
+export default {
+  component: DataCard,
+  title: "ERDDAP|CurrentConditions/Data Card",
+}
+
+export const configurable = () => {
+  const options = [UnitSystem.english, UnitSystem.metric]
+  const unit = select("Unit System", options, options[0], "unit-system-0")
+  return <DataCard platform={platform} unit_system={unit} data_types={["significant_wave_height", "max_wave_height"]} />
+}

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
@@ -44,15 +44,6 @@ export const DataCard: React.SFC<DataCardProps> = ({ platform, data_types, unit_
 
   let reading = filtered_datasets[0]
 
-  let depth: string
-  if (reading.depth === undefined || reading.depth <= 5) {
-    depth = ""
-  } else if (reading.depth > 0) {
-    depth = " @ " + reading.depth + "m"
-  } else {
-    depth = " @ " + -reading.depth + "m"
-  }
-
   let data = reading.readings
 
   // If there is no current data, display a card letting us know
@@ -87,8 +78,7 @@ export const DataCard: React.SFC<DataCardProps> = ({ platform, data_types, unit_
       >
         <Card>
           <CardHeader>
-            {reading.data_type.long_name + depth} -{" "}
-            {round(data_converter.convertTo(latest.reading, unit_system) as number, 1)}{" "}
+            {reading.data_type.long_name} - {round(data_converter.convertTo(latest.reading, unit_system) as number, 1)}{" "}
             {data_converter.displayName(unit_system)} {convertUnit(reading.data_type.units, latest.reading)}
           </CardHeader>
           <CardBody style={{ padding: ".2rem" }}>

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
@@ -1,0 +1,109 @@
+import React from "react"
+import { Link } from "react-router-dom"
+import { Card, CardBody, CardHeader, Col } from "reactstrap"
+
+import { SmallTimeSeriesChart } from "components/Charts"
+import { paths } from "Shared/constants"
+
+import { naturalBounds } from "Shared/dataTypes"
+import { round } from "Shared/math"
+import { convertUnit } from "Shared/unitConversion"
+import { urlPartReplacer } from "Shared/urlParams"
+import { UnitSystem } from "Features/Units/types"
+import { converter } from "Features/Units/Converter"
+
+import { PlatformFeatureWithDatasets, PlatformDataset } from "../../../types"
+
+interface DataCardProps {
+  platform: PlatformFeatureWithDatasets
+  data_types: string[]
+  unit_system: UnitSystem
+}
+
+const cardProps = {
+  md: "4",
+  sm: "6",
+  style: {
+    paddingTop: "1rem",
+  },
+}
+
+export const DataCard: React.SFC<DataCardProps> = ({ platform, data_types, unit_system }) => {
+  let filtered_datasets: PlatformDataset[] = []
+
+  data_types.forEach((data_type) => {
+    platform.properties.readings
+      .filter((reading) => data_type === reading.data_type.standard_name)
+      .forEach((reading) => filtered_datasets.push(reading))
+  })
+
+  // Don't return anything if there are no datasets
+  if (filtered_datasets.length === 0) {
+    return null
+  }
+
+  let reading = filtered_datasets[0]
+
+  let depth: string
+  if (reading.depth === undefined || reading.depth <= 5) {
+    depth = ""
+  } else if (reading.depth > 0) {
+    depth = " @ " + reading.depth + "m"
+  } else {
+    depth = " @ " + -reading.depth + "m"
+  }
+
+  let data = reading.readings
+
+  // If there is no current data, display a card letting us know
+  if (data.length === 0) {
+    return (
+      <Col {...cardProps} key={reading.data_type.standard_name}>
+        <Card>
+          <CardBody>No data for {reading.data_type.long_name} in the last day.</CardBody>
+        </Card>
+      </Col>
+    )
+  }
+
+  const latest = data[data.length - 1]
+  const bounds = naturalBounds(reading.data_type.standard_name)
+
+  const data_converter = converter(reading.data_type.standard_name)
+
+  data = data.map((r) => ({
+    ...r,
+    reading: round(data_converter.convertTo(r.reading, unit_system) as number, 2),
+  }))
+
+  return (
+    <Col key={reading.data_type.standard_name} {...cardProps}>
+      <Link
+        to={urlPartReplacer(
+          urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
+          ":type",
+          reading.data_type.standard_name
+        )}
+      >
+        <Card>
+          <CardHeader>
+            {reading.data_type.long_name + depth} -{" "}
+            {round(data_converter.convertTo(latest.reading, unit_system) as number, 1)}{" "}
+            {data_converter.displayName(unit_system)} {convertUnit(reading.data_type.units, latest.reading)}
+          </CardHeader>
+          <CardBody style={{ padding: ".2rem" }}>
+            <SmallTimeSeriesChart
+              name={reading.data_type.standard_name}
+              timeSeries={data}
+              unit={data_converter.displayName(unit_system)}
+              softMin={bounds[0]}
+              softMax={bounds[1]}
+              unit_system={unit_system}
+              data_type={reading.data_type.standard_name}
+            />
+          </CardBody>
+        </Card>
+      </Link>
+    </Col>
+  )
+}

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
@@ -37,12 +37,28 @@ describe("TableItem", () => {
 
     expect(wrapper.text()).toBe("")
   })
+
+  it("Returns only the first selected datatype", () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <TableItem
+          platform={platform}
+          data_type={["significant_wave_height", "significant_height_of_wind_and_swell_waves_3"]}
+          unit_system={UnitSystem.english}
+          name="Wave Height"
+        />
+      </MemoryRouter>
+    )
+
+    expect(wrapper.text()).toContain("Wave Height: 0.8 Feet")
+    expect(wrapper.text()).not.toContain("Wave Height: 1.1 Feet")
+  })
 })
 
 const platform: PlatformFeatureWithDatasets = {
   geometry: {
     coordinates: [0, 0],
-    type: "Point"
+    type: "Point",
   },
   id: "N01",
   properties: {
@@ -55,7 +71,7 @@ const platform: PlatformFeatureWithDatasets = {
           long_name: "Wind Speed",
           short_name: "WSPD",
           standard_name: "wind_speed",
-          units: "m/s"
+          units: "m/s",
         },
         dataset: "N01",
         depth: -2,
@@ -65,9 +81,54 @@ const platform: PlatformFeatureWithDatasets = {
         server: "neracoos",
         start_time: "2019-01-02T16:31:10.088Z",
         value: 4.25,
-        variable: "wind"
-      }
-    ]
+        variable: "wind",
+      },
+      {
+        value: 0.310469806194305,
+        time: "2020-06-02T15:59:59.999986Z",
+        depth: null,
+        data_type: {
+          standard_name: "significant_height_of_wind_and_swell_waves_3",
+          short_name: "WVHT",
+          long_name: "Significant Wave Height",
+          units: "m",
+        },
+        server: "http://www.neracoos.org/erddap",
+        variable: "significant_wave_height",
+        constraints: {
+          "significant_wave_height_qc=": 0,
+        },
+        dataset: "E01_accelerometer_all",
+        start_time: "2020-04-29T12:10:23Z",
+        error: "",
+        loadStartTimes: [],
+        loading: false,
+        readings: [],
+      },
+
+      {
+        value: 0.229300007224083,
+        time: "2020-06-02T15:59:59.999986Z",
+        depth: null,
+        data_type: {
+          standard_name: "significant_wave_height",
+          short_name: "SWH",
+          long_name: "Significant Wave Height",
+          units: "m",
+        },
+        server: "http://www.neracoos.org/erddap",
+        variable: "significant_wave_height_3",
+        constraints: {
+          "significant_wave_height_3_qc=": 0,
+        },
+        dataset: "E01_waves_mstrain_all",
+        start_time: "2019-05-29T19:13:14Z",
+        error: "",
+        loadStartTimes: [],
+        loading: false,
+        readings: [],
+      },
+    ],
   },
-  type: "Feature"
+  type: "Feature",
 }

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -7,24 +7,36 @@ import { urlPartReplacer } from "Shared/urlParams"
 import { UnitSystem } from "Features/Units/types"
 import { converter } from "Features/Units/Converter"
 
-import { PlatformFeatureWithDatasets } from "../../../types"
+import { PlatformFeatureWithDatasets, PlatformDataset } from "../../../types"
 
 export const itemStyle = { padding: ".5rem", paddingLeft: "1rem", color: "black" }
 
 interface TableItemProps {
   platform: PlatformFeatureWithDatasets
-  data_type: string
+  data_type: string | string[]
   name: string
   unit_system: UnitSystem
 }
 
 export const TableItem: React.SFC<TableItemProps> = ({ platform, data_type, name, unit_system }: TableItemProps) => {
-  const data = platform.properties.readings.filter(ts => ts.data_type.standard_name === data_type)
+  let data_type_list: string[]
+
+  if (typeof data_type === "string") {
+    data_type_list = [data_type]
+  } else {
+    data_type_list = data_type
+  }
+
+  let data: PlatformDataset[] = []
+
+  data_type_list.forEach((data_type) => {
+    platform.properties.readings.filter((ts) => data_type === ts.data_type.standard_name).forEach((ts) => data.push(ts))
+  })
 
   if (data.length > 0) {
     const selected = data[0]
 
-    const unit_converter = converter(data_type)
+    const unit_converter = converter(typeof data_type === "string" ? data_type : data_type[0])
 
     const value = unit_converter.convertTo(selected.value as number, unit_system)
 

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -16,7 +16,7 @@ interface Props {
  * @param platform
  */
 export const ErddapObservationTable: React.SFC<Props & RenderProps> = ({ platform, unitSelector, unit_system }) => {
-  const times = platform.properties.readings.filter(d => d.time !== null).map(d => new Date(d.time as string))
+  const times = platform.properties.readings.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
   times.sort((a, b) => a.valueOf() - b.valueOf())
 
   return (
@@ -33,24 +33,22 @@ export const ErddapObservationTable: React.SFC<Props & RenderProps> = ({ platfor
 
       <TableItem
         platform={platform}
-        data_type="sea_surface_wave_significant_height"
-        name="Wave Height"
-        unit_system={unit_system}
-      />
-      <TableItem
-        platform={platform}
-        data_type="significant_height_of_wind_and_swell_waves"
+        data_type={[
+          "sea_surface_wave_significant_height",
+          "significant_wave_height",
+          "significant_height_of_wind_and_swell_waves",
+          "significant_height_of_wind_and_swell_waves_3",
+        ]}
         name="Wave Height"
         unit_system={unit_system}
       />
 
       <TableItem
         platform={platform}
-        data_type="sea_surface_swell_wave_period"
+        data_type={["sea_surface_swell_wave_period", "dominant_wave_period"]}
         name="Wave Period"
         unit_system={unit_system}
       />
-      <TableItem platform={platform} data_type="dominant_wave_period" name="Wave Period" unit_system={unit_system} />
 
       <TableItem platform={platform} data_type="mean_wave_direction" name="Wave Direction" unit_system={unit_system} />
       <TableItem platform={platform} data_type="air_temperature" name="Air Temperature" unit_system={unit_system} />

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -26,9 +26,9 @@ export const Footer: React.SFC = () => (
         </a>
       </Col>
     </Row>
-    <Row style={textStyle}>
+    <Row style={{ marginTop: "1rem", marginBottom: "1rem", ...textStyle }}>
       <Col md={colSize} className="mx-auto text-center">
-        <a href="http://neracoos.org">
+        <a href="http://neracoos.org" style={{ paddingRight: "1rem" }}>
           <img src={neracoos} style={logoStyle} alt="NERACOOS" title="NERACOOS" />
         </a>
         <a href="https://www.gmri.org/our-work/research/our-approach/ocean-data">

--- a/src/stories/__snapshots__/storyshots.test.ts.snap
+++ b/src/stories/__snapshots__/storyshots.test.ts.snap
@@ -2769,6 +2769,27 @@ exports[`Storyshots ERDDAP|ObservationTable/Current Configurable 1`] = `
   </a>
   <a
     className="list-group-item"
+    href="/platform/M01/observations/significant_wave_height"
+    onClick={[Function]}
+    style={
+      Object {
+        "color": "black",
+        "padding": ".5rem",
+        "paddingLeft": "1rem",
+      }
+    }
+  >
+    <b>
+      Wave Height
+      :
+    </b>
+     
+    4.6
+     
+    Feet
+  </a>
+  <a
+    className="list-group-item"
     href="/platform/M01/observations/dominant_wave_period"
     onClick={[Function]}
     style={
@@ -2941,6 +2962,27 @@ exports[`Storyshots ERDDAP|ObservationTable/Current English 1`] = `
   </a>
   <a
     className="list-group-item"
+    href="/platform/M01/observations/significant_wave_height"
+    onClick={[Function]}
+    style={
+      Object {
+        "color": "black",
+        "padding": ".5rem",
+        "paddingLeft": "1rem",
+      }
+    }
+  >
+    <b>
+      Wave Height
+      :
+    </b>
+     
+    4.6
+     
+    Feet
+  </a>
+  <a
+    className="list-group-item"
     href="/platform/M01/observations/dominant_wave_period"
     onClick={[Function]}
     style={
@@ -3092,6 +3134,27 @@ exports[`Storyshots ERDDAP|ObservationTable/Current Metric 1`] = `
     44.5
      
     Degrees
+  </a>
+  <a
+    className="list-group-item"
+    href="/platform/M01/observations/significant_wave_height"
+    onClick={[Function]}
+    style={
+      Object {
+        "color": "black",
+        "padding": ".5rem",
+        "paddingLeft": "1rem",
+      }
+    }
+  >
+    <b>
+      Wave Height
+      :
+    </b>
+     
+    1.4
+     
+    Meters
   </a>
   <a
     className="list-group-item"

--- a/src/stories/__snapshots__/storyshots.test.ts.snap
+++ b/src/stories/__snapshots__/storyshots.test.ts.snap
@@ -296,8 +296,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
           className="card-header"
         >
           Air Temperature
-           -
-           
+           - 
           38.9
            
           Fahrenheit
@@ -338,8 +337,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
           className="card-header"
         >
           Barometric Pressure
-           -
-           
+           - 
           14.7
            
           psi
@@ -380,8 +378,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
           className="card-header"
         >
           Significant Wave Height
-           -
-           
+           - 
           5.2
            
           Feet
@@ -422,8 +419,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
           className="card-header"
         >
           Dominant Wave Period
-           -
-           
+           - 
           6.3
            
           Seconds
@@ -484,8 +480,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
           className="card-header"
         >
           Visibility
-           -
-           
+           - 
           1.7
            
           Nautical Miles
@@ -567,8 +562,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
           className="card-header"
         >
           Air Temperature
-           -
-           
+           - 
           38.9
            
           Fahrenheit
@@ -609,8 +603,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
           className="card-header"
         >
           Barometric Pressure
-           -
-           
+           - 
           14.7
            
           psi
@@ -651,8 +644,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
           className="card-header"
         >
           Significant Wave Height
-           -
-           
+           - 
           5.2
            
           Feet
@@ -693,8 +685,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
           className="card-header"
         >
           Dominant Wave Period
-           -
-           
+           - 
           6.3
            
           Seconds
@@ -755,8 +746,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
           className="card-header"
         >
           Visibility
-           -
-           
+           - 
           1.7
            
           Nautical Miles
@@ -838,8 +828,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
           className="card-header"
         >
           Air Temperature
-           -
-           
+           - 
           3.9
            
           Celsius
@@ -880,8 +869,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
           className="card-header"
         >
           Barometric Pressure
-           -
-           
+           - 
           1012.9
            
           hPa
@@ -922,8 +910,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
           className="card-header"
         >
           Significant Wave Height
-           -
-           
+           - 
           1.6
            
           Meters
@@ -964,8 +951,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
           className="card-header"
         >
           Dominant Wave Period
-           -
-           
+           - 
           6.3
            
           Seconds
@@ -1026,8 +1012,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
           className="card-header"
         >
           Visibility
-           -
-           
+           - 
           3
            
           Kilometers
@@ -1072,8 +1057,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Data Card Configurable 1`] = `
         className="card-header"
       >
         Significant Wave Height
-         -
-         
+         - 
         5.2
          
         Feet

--- a/src/stories/__snapshots__/storyshots.test.ts.snap
+++ b/src/stories/__snapshots__/storyshots.test.ts.snap
@@ -52,6 +52,8 @@ exports[`Storyshots Components|Footer Footer 1`] = `
     style={
       Object {
         "fontSize": ".8rem",
+        "marginBottom": "1rem",
+        "marginTop": "1rem",
         "padding": ".25rem",
       }
     }
@@ -61,6 +63,11 @@ exports[`Storyshots Components|Footer Footer 1`] = `
     >
       <a
         href="http://neracoos.org"
+        style={
+          Object {
+            "paddingRight": "1rem",
+          }
+        }
       >
         <img
           alt="NERACOOS"
@@ -279,48 +286,6 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
     }
   >
     <a
-      href="/platform/M01/observations/dominant_wave_period"
-      onClick={[Function]}
-    >
-      <div
-        className="card"
-      >
-        <div
-          className="card-header"
-        >
-          Dominant Wave Period
-           -
-           
-          6.3
-           
-          Seconds
-           
-          
-        </div>
-        <div
-          className="card-body"
-          style={
-            Object {
-              "padding": ".2rem",
-            }
-          }
-        >
-          <div
-            className="chart "
-          />
-        </div>
-      </div>
-    </a>
-  </div>
-  <div
-    className="col-sm-6 col-md-4"
-    style={
-      Object {
-        "paddingTop": "1rem",
-      }
-    }
-  >
-    <a
       href="/platform/M01/observations/air_temperature"
       onClick={[Function]}
     >
@@ -405,7 +370,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
     }
   >
     <a
-      href="/platform/M01/observations/sea_water_temperature"
+      href="/platform/M01/observations/significant_wave_height"
       onClick={[Function]}
     >
       <div
@@ -414,12 +379,54 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Configurable 1`] = `
         <div
           className="card-header"
         >
-          Water Temperature
+          Significant Wave Height
            -
            
-          41.3
+          5.2
            
-          Fahrenheit
+          Feet
+           
+          
+        </div>
+        <div
+          className="card-body"
+          style={
+            Object {
+              "padding": ".2rem",
+            }
+          }
+        >
+          <div
+            className="chart "
+          />
+        </div>
+      </div>
+    </a>
+  </div>
+  <div
+    className="col-sm-6 col-md-4"
+    style={
+      Object {
+        "paddingTop": "1rem",
+      }
+    }
+  >
+    <a
+      href="/platform/M01/observations/dominant_wave_period"
+      onClick={[Function]}
+    >
+      <div
+        className="card"
+      >
+        <div
+          className="card-header"
+        >
+          Dominant Wave Period
+           -
+           
+          6.3
+           
+          Seconds
            
           
         </div>
@@ -550,48 +557,6 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
     }
   >
     <a
-      href="/platform/M01/observations/dominant_wave_period"
-      onClick={[Function]}
-    >
-      <div
-        className="card"
-      >
-        <div
-          className="card-header"
-        >
-          Dominant Wave Period
-           -
-           
-          6.3
-           
-          Seconds
-           
-          
-        </div>
-        <div
-          className="card-body"
-          style={
-            Object {
-              "padding": ".2rem",
-            }
-          }
-        >
-          <div
-            className="chart "
-          />
-        </div>
-      </div>
-    </a>
-  </div>
-  <div
-    className="col-sm-6 col-md-4"
-    style={
-      Object {
-        "paddingTop": "1rem",
-      }
-    }
-  >
-    <a
       href="/platform/M01/observations/air_temperature"
       onClick={[Function]}
     >
@@ -676,7 +641,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
     }
   >
     <a
-      href="/platform/M01/observations/sea_water_temperature"
+      href="/platform/M01/observations/significant_wave_height"
       onClick={[Function]}
     >
       <div
@@ -685,12 +650,54 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable English 1`] = `
         <div
           className="card-header"
         >
-          Water Temperature
+          Significant Wave Height
            -
            
-          41.3
+          5.2
            
-          Fahrenheit
+          Feet
+           
+          
+        </div>
+        <div
+          className="card-body"
+          style={
+            Object {
+              "padding": ".2rem",
+            }
+          }
+        >
+          <div
+            className="chart "
+          />
+        </div>
+      </div>
+    </a>
+  </div>
+  <div
+    className="col-sm-6 col-md-4"
+    style={
+      Object {
+        "paddingTop": "1rem",
+      }
+    }
+  >
+    <a
+      href="/platform/M01/observations/dominant_wave_period"
+      onClick={[Function]}
+    >
+      <div
+        className="card"
+      >
+        <div
+          className="card-header"
+        >
+          Dominant Wave Period
+           -
+           
+          6.3
+           
+          Seconds
            
           
         </div>
@@ -821,48 +828,6 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
     }
   >
     <a
-      href="/platform/M01/observations/dominant_wave_period"
-      onClick={[Function]}
-    >
-      <div
-        className="card"
-      >
-        <div
-          className="card-header"
-        >
-          Dominant Wave Period
-           -
-           
-          6.3
-           
-          Seconds
-           
-          
-        </div>
-        <div
-          className="card-body"
-          style={
-            Object {
-              "padding": ".2rem",
-            }
-          }
-        >
-          <div
-            className="chart "
-          />
-        </div>
-      </div>
-    </a>
-  </div>
-  <div
-    className="col-sm-6 col-md-4"
-    style={
-      Object {
-        "paddingTop": "1rem",
-      }
-    }
-  >
-    <a
       href="/platform/M01/observations/air_temperature"
       onClick={[Function]}
     >
@@ -947,7 +912,7 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
     }
   >
     <a
-      href="/platform/M01/observations/sea_water_temperature"
+      href="/platform/M01/observations/significant_wave_height"
       onClick={[Function]}
     >
       <div
@@ -956,12 +921,54 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
         <div
           className="card-header"
         >
-          Water Temperature
+          Significant Wave Height
            -
            
-          5.2
+          1.6
            
-          Celsius
+          Meters
+           
+          
+        </div>
+        <div
+          className="card-body"
+          style={
+            Object {
+              "padding": ".2rem",
+            }
+          }
+        >
+          <div
+            className="chart "
+          />
+        </div>
+      </div>
+    </a>
+  </div>
+  <div
+    className="col-sm-6 col-md-4"
+    style={
+      Object {
+        "paddingTop": "1rem",
+      }
+    }
+  >
+    <a
+      href="/platform/M01/observations/dominant_wave_period"
+      onClick={[Function]}
+    >
+      <div
+        className="card"
+      >
+        <div
+          className="card-header"
+        >
+          Dominant Wave Period
+           -
+           
+          6.3
+           
+          Seconds
            
           
         </div>
@@ -1042,6 +1049,51 @@ exports[`Storyshots ERDDAP|CurrentConditions/Configurable Metric 1`] = `
       </div>
     </a>
   </div>
+</div>
+`;
+
+exports[`Storyshots ERDDAP|CurrentConditions/Data Card Configurable 1`] = `
+<div
+  className="col-sm-6 col-md-4"
+  style={
+    Object {
+      "paddingTop": "1rem",
+    }
+  }
+>
+  <a
+    href="/platform/M01/observations/significant_wave_height"
+    onClick={[Function]}
+  >
+    <div
+      className="card"
+    >
+      <div
+        className="card-header"
+      >
+        Significant Wave Height
+         -
+         
+        5.2
+         
+        Feet
+         
+        
+      </div>
+      <div
+        className="card-body"
+        style={
+          Object {
+            "padding": ".2rem",
+          }
+        }
+      >
+        <div
+          className="chart "
+        />
+      </div>
+    </div>
+  </a>
 </div>
 `;
 


### PR DESCRIPTION
For both the current conditions graphs and table, it matched by individual data types. This meant that platforms that have multiple sensor packages reading the same values, there might be multiple sets of the same information displayed.

Now you can specify a list of data types to display, and it find the first matching one to display.

CU-7rdn5m