### PR TITLE
Split latest actions into separate workflow

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,0 +1,45 @@
+name: "Latest"
+
+on:
+  workflow_run:
+    workflows: ["Push"]
+    branches: [master, main]
+    types:
+      - completed
+env:
+  LATEST_IMAGE: gmri/neracoos-mariners-dashboard:latest
+  TAGGED_IMAGE: gmri/neracoos-mariners-dashboard:${{ github.sha }}
+
+jobs:
+  latest:
+    name: Tag latest Docker image and Github Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v1
+
+      - name: "Login to Docker Hub"
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Pull Docker image
+        run: docker pull ${TAGGED_IMAGE}
+
+      - name: Tag Docker image
+        run: docker tag ${TAGGED_IMAGE} ${LATEST_IMAGE}
+
+      - name: Push Docker image
+        run: docker push ${LATEST_IMAGE}
+
+      - name: Build Storybook Pages
+        run: docker-compose run client yarn build-storybook
+
+      - name: Deploy Storybook to Github Pages 🚀
+        uses: JamesIves/github-pages-deploy-action@3.4.8
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: storybook-public

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "Push"
 
 on: [push]
 env:
@@ -114,38 +114,3 @@ jobs:
         run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }}
         timeout-minutes: 15
         if: failure()
-
-  latest:
-    name: Tag latest Docker image and Github Pages
-    runs-on: ubuntu-latest
-    needs: [build, cypress]
-    if: github.ref == 'refs/heads/master'
-
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v1
-
-      - name: "Login to Docker Hub"
-        uses: azure/docker-login@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Pull Docker image
-        run: docker pull ${TAGGED_IMAGE}
-
-      - name: Tag Docker image
-        run: docker tag ${TAGGED_IMAGE} ${LATEST_IMAGE}
-
-      - name: Push Docker image
-        run: docker push ${LATEST_IMAGE}
-
-      - name: Build Storybook Pages
-        run: docker-compose run client yarn build-storybook
-
-      - name: Deploy Storybook to Github Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@3.4.8
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: storybook-public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ Changes:
 Fixes:
 
 - A little extra breathing space withing the footer.
+
+Testing:
+
 - Test A01 and skip M01 wind test.
+- Separate push actions from those only supposed to run on master/main branch.
 
 ## 0.4.1 - 5/31/2020
 
@@ -54,7 +58,7 @@ Changes:
   - React Redux from 7.1.3 to 7.2.0
   - React Router DOM from 5.1.2 to 5.2.0
   - React Scripts from 3.3.1 to 3.4.0
-  - Stoybook
+  - Storybook
     - Addon A11y from 5.3.10 to 5.3.18
     - Addon actions 5.3.13 to 5.3.19
     - Addon docs from 5.3.10 to 5.3.18


### PR DESCRIPTION
Instead of having a job that is only supposed to happen on the main/master branch, use the [`workflow_run`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run) trigger to follow the push workflow.