### PR TITLE
Only run the latest workflow is the push workflow was successful

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -14,6 +14,7 @@ jobs:
   latest:
     name: Tag latest Docker image and Github Pages
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
https://github.community/t/workflow-run-completed-event-triggered-by-failed-workflow/128001