### PR TITLE
Filter current conditions table by date and strip nulls on the client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changes:
 
 Fixes:
 
+- Filter recent conditions table by date.
+- Filter nulls on the client side from ERDDAP requests rather than using constraints to remove them.
+
 ## 0.5.5 - 10/2/2020
 
 Changes:

--- a/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
@@ -42,6 +42,7 @@ export const ErddapAllObservationsTable: React.FunctionComponent<Props> = ({ pla
           <TableItem
             key={index}
             platform={platform}
+            readings={platform.properties.readings}
             data_type={dataset.data_type.standard_name}
             name={name}
             unitSystem={unitSystem}

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
@@ -4,14 +4,14 @@ import { MemoryRouter } from "react-router-dom"
 
 import { UnitSystem } from "Features/Units/types"
 
-import { PlatformFeatureWithDatasets } from "../../../types"
+import { PlatformFeature } from "../../../types"
 import { TableItem } from "./item"
 
 describe("TableItem", () => {
   it("Selectes and renders correct data", () => {
     const wrapper = mount(
       <MemoryRouter>
-        <TableItem platform={platform} data_type="wind_speed" name="Wind Speed" unitSystem={UnitSystem.english} />
+        <TableItem platform={platform} readings={platform.properties.readings} data_type="wind_speed" name="Wind Speed" unitSystem={UnitSystem.english} />
       </MemoryRouter>
     )
 
@@ -21,7 +21,7 @@ describe("TableItem", () => {
   it("Rounds the wind speed", () => {
     const wrapper = mount(
       <MemoryRouter>
-        <TableItem platform={platform} data_type="wind_speed" name="Wind Speed" unitSystem={UnitSystem.metric} />
+        <TableItem platform={platform} readings={platform.properties.readings} data_type="wind_speed" name="Wind Speed" unitSystem={UnitSystem.metric} />
       </MemoryRouter>
     )
 
@@ -31,7 +31,7 @@ describe("TableItem", () => {
   it("Returns null when there is not a matching datatype", () => {
     const wrapper = mount(
       <MemoryRouter>
-        <TableItem platform={platform} data_type="air_temp" unitSystem={UnitSystem.english} name="Air Temp" />
+        <TableItem platform={platform} readings={platform.properties.readings} data_type="air_temp" unitSystem={UnitSystem.english} name="Air Temp" />
       </MemoryRouter>
     )
 
@@ -46,7 +46,7 @@ describe("TableItem", () => {
     const wrapper = mount(
       <MemoryRouter>
         <TableItem
-          platform={platform}
+          platform={platform} readings={platform.properties.readings}
           data_type={["significant_wave_height", "significant_height_of_wind_and_swell_waves_3"]}
           unitSystem={UnitSystem.english}
           name="Wave Height"
@@ -60,7 +60,7 @@ describe("TableItem", () => {
   })
 })
 
-const platform: PlatformFeatureWithDatasets = {
+const platform: PlatformFeature = {
   geometry: {
     coordinates: [0, 0],
     type: "Point",

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -17,6 +17,7 @@ export const itemStyle = { padding: ".5rem", paddingLeft: "1rem", color: "black"
 
 interface TableItemProps {
   platform: PlatformFeature
+  readings: PlatformTimeSeries[]
   data_type: string | string[]
   name: string
   unitSystem: UnitSystem
@@ -29,6 +30,7 @@ interface TableItemProps {
  */
 export const TableItem: React.FunctionComponent<TableItemProps> = ({
   platform,
+  readings,
   data_type,
   name,
   unitSystem,
@@ -49,7 +51,7 @@ export const TableItem: React.FunctionComponent<TableItemProps> = ({
   let data: PlatformTimeSeries[] = []
 
   data_type_list.forEach((data_type) => {
-    platform.properties.readings
+    readings
       .filter((ts) => data_type === ts.data_type.standard_name && (ts.depth ? ts.depth < 2 : true))
       .forEach((ts) => data.push(ts))
   })

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -14,6 +14,7 @@ import { itemStyle, TableItem } from "./item"
 interface Props extends UsePlatformRenderProps {
   unitSelector?: React.ReactNode
   unitSystem: UnitSystem
+  laterThan?: Date
 }
 
 const timeDelta = 60 * 60 * 1000
@@ -22,12 +23,27 @@ const timeDelta = 60 * 60 * 1000
  * Recent platform observation values
  * @param platform
  */
-export const ErddapObservationTable: React.FunctionComponent<Props> = ({ platform, unitSelector, unitSystem }) => {
-  const times = platform.properties.readings.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
+export const ErddapObservationTable: React.FunctionComponent<Props> = ({ platform, unitSelector, unitSystem, laterThan }) => {
+  const readings = platform.properties.readings.filter(d => {
+    if (d.time) {
+      if (laterThan) {
+        return laterThan <= new Date(d.time)
+      }
+
+      return true
+    }
+    return false
+  })
+
+
+
+  const times = readings.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
   times.sort((a, b) => a.valueOf() - b.valueOf())
 
   /** Sixty minute window for updated times */
   const timeWindow = times.length > 0 ? new Date(times[times.length - 1].getTime() - timeDelta) : undefined
+
+  const commonProps = {platform, readings, unitSystem, later_than: timeWindow}
 
   return (
     <ListGroup style={{ paddingTop: "1rem" }}>
@@ -42,73 +58,57 @@ export const ErddapObservationTable: React.FunctionComponent<Props> = ({ platfor
             day: "numeric",
           })}
         </ListGroupItem>
-      ) : null}
+      ) : (
+        <ListGroupItem style={itemStyle}>There is no recent data from {platform.id}</ListGroupItem>
+      )}
 
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.windSpeed}
         name="Wind Speed"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.windGust}
         name="Wind Gusts"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.windDirection}
         name="Wind Direction"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
 
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.waveHeight}
         name="Wave Height"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
 
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.wavePeriod}
         name="Wave Period"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
 
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.waveDirection}
         name="Wave Direction"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.airTemp}
         name="Air Temperature"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.waterTemp}
         name="Water Temperature"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
       <TableItem
-        platform={platform}
+        {...commonProps}
         data_type={conditions.visibility}
         name="Visibility"
-        unitSystem={unitSystem}
-        later_then={timeWindow}
       />
 
       {unitSelector ? (

--- a/src/Pages/Platforms/platformInfo.tsx
+++ b/src/Pages/Platforms/platformInfo.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from "react-router-dom"
 
 import { ErddapObservationTable, ErddapPlatformInfoPanel, PlatformAlerts, UsePlatform } from "Features/ERDDAP"
 import { UnitSelector, useUnitSystem } from "Features/Units"
+import { aDayAgoRounded } from "Shared/time"
 
 import { PlatformMatchParams } from "./types"
 
@@ -13,13 +14,15 @@ export const PlatformInfo: React.FunctionComponent<RouteComponentProps> = ({ mat
   const { id } = match.params as PlatformMatchParams
   const unitSystem = useUnitSystem()
 
+  const aDayAgo = aDayAgoRounded()
+
   return (
     <UsePlatform platformId={id}>
       {({ platform }) => (
         <React.Fragment>
           <PlatformAlerts platform={platform} />
           <ErddapPlatformInfoPanel platform={platform} />
-          <ErddapObservationTable platform={platform} unitSelector={<UnitSelector />} unitSystem={unitSystem} />
+          <ErddapObservationTable platform={platform} unitSelector={<UnitSelector />} unitSystem={unitSystem} laterThan={aDayAgo} />
         </React.Fragment>
       )}
     </UsePlatform>

--- a/src/Shared/erddap/tabledap.ts
+++ b/src/Shared/erddap/tabledap.ts
@@ -92,9 +92,9 @@ export function resultToTimeseries(result: ErddapJson, variables: string[]): Dat
 
     output.push({
       name: variable,
-      timeSeries: result.table.rows.map((row) => ({
+      timeSeries: result.table.rows.filter(row => row[varIndex] !== null).map((row) => ({
         reading: row[varIndex] as number,
-        time: new Date(row[timeIndex]),
+        time: new Date(row[timeIndex] as string),
       })),
       unit: result.table.columnUnits[varIndex],
     })

--- a/src/Shared/erddap/types.ts
+++ b/src/Shared/erddap/types.ts
@@ -36,6 +36,6 @@ export interface ErddapJson {
     columnNames: string[]
     columnTypes: string[]
     columnUnits: string[]
-    rows: Array<Array<number | string>>
+    rows: Array<Array<number | string | null>>
   }
 }


### PR DESCRIPTION
Stripping nulls on the client side reduces the number of constraints needed (each constraint combo adds an extra request when there are multiple datasets to display).