### PR TITLE
Cypress Fetch Errors

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -109,8 +109,12 @@ jobs:
       - name: Run Cypress
         run: npx cypress run
         timeout-minutes: 15
+        env:
+          NO_PROXY: neracoos.org
 
       - name: Run Cypress and send results to dashboard if the previous run failed
         run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }}
         timeout-minutes: 15
         if: failure()
+        env:
+          NO_PROXY: neracoos.org


### PR DESCRIPTION
Check if setting `NO_PROXY=neracoos.org` will do the trick.