### PR TITLE
Show data sources for forecast data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes:
 
 - Show the current time on the forecast plots.
 - Support loading multiple forecasts via `useQueries()`.
+- Show forecast data sources.
 
 Fixes:
 

--- a/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
+++ b/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
@@ -7,6 +7,7 @@ import { Alert, Row, Col } from "reactstrap"
 
 import { MultipleLargeTimeSeriesChartCurrent } from "components/Charts"
 import { round } from "Shared/math"
+import { tabledapHtmlUrl } from "Shared/erddap/tabledap"
 import { aDayAgoRounded } from "Shared/time"
 import { DataTimeSeries, ReadingTimeSeries } from "Shared/timeSeries"
 import { UnitSystem } from "Features/Units/types"
@@ -20,6 +21,10 @@ interface Props {
   platform: PlatformFeature
   forecast_type: string
   unitSystem: UnitSystem
+}
+
+interface UrlDataTimeSeries extends DataTimeSeries {
+  url: string
 }
 
 /**
@@ -48,7 +53,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
     result: results[index],
   }))
 
-  const chartData: DataTimeSeries[] = []
+  const chartData: UrlDataTimeSeries[] = []
 
   if (dataset && timeSeries) {
     const aDayAgo = aDayAgoRounded()
@@ -57,6 +62,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
       ...dataset,
       timeSeries: dataset.timeSeries.filter((r) => aDayAgo < r.time),
       name: `${timeSeries.dataset}: ${timeSeries.data_type.long_name}`,
+      url: tabledapHtmlUrl(timeSeries.server, timeSeries.dataset, [timeSeries.variable], timeSeries.constraints),
     })
   }
 
@@ -66,6 +72,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
         timeSeries: result.data as ReadingTimeSeries[],
         name: meta.name,
         unit: meta.units,
+        url: meta.source_url,
       })
     }
   })
@@ -90,6 +97,15 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
         <h4>{forecasts[0].forecast_type} Forecast</h4>
 
         <ForecastChart type={forecast_type} unitSystem={unitSystem} data={chartData} />
+
+        <h6>Data sources</h6>
+        <ul>
+          {chartData.map(({ name, url }) => (
+            <li key={name}>
+              <a href={url}>{name}</a>
+            </li>
+          ))}
+        </ul>
       </Col>
     </Row>
   )


### PR DESCRIPTION
On the forecast pages, include links to the dataset and forecast data displayed.

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/1296209/108630821-ca888c80-7434-11eb-8eb2-781a957061b7.png">
