### PR TITLE
Remove datasets and add obs/forecast to chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Additions:
 
 Changes:
 
+- Hide dataset links on chart pages.
+- Show observations/forecast next to data types on forecasts.
+
 Fixes:
 
 ## 0.6.6 - 3/8/2021

--- a/cypress/integration/Platform/a01_spec.js
+++ b/cypress/integration/Platform/a01_spec.js
@@ -38,8 +38,6 @@ describe("Platform A01", () => {
     cy.contains("Air Temperature:").click()
 
     cy.get("h4").contains("Air Temperature")
-
-    cy.contains("Data from the air_temperature variable in the A01_met_all dataset.")
   })
 
   it("Shows wind plot", () => {

--- a/cypress/integration/Platform/m01_spec.js
+++ b/cypress/integration/Platform/m01_spec.js
@@ -38,8 +38,6 @@ describe("Platfrom M01", () => {
     cy.contains("Air Temperature:").click()
 
     cy.get("h4").contains("Air Temperature")
-
-    cy.contains("Data from the air_temperature variable in the M01_met_all dataset.")
   })
 
   xit("Shows wind plot", () => {

--- a/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
+++ b/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
@@ -3,9 +3,11 @@
  */
 import { Point } from "@turf/helpers"
 import React from "react"
+import { Link } from "react-router-dom"
 import { Alert, Row, Col } from "reactstrap"
 
 import { MultipleLargeTimeSeriesChartCurrent } from "components/Charts"
+import { paths } from "Shared/constants"
 import { round } from "Shared/math"
 import { tabledapHtmlUrl } from "Shared/erddap/tabledap"
 import { aDayAgoRounded } from "Shared/time"
@@ -61,7 +63,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
     chartData.push({
       ...dataset,
       timeSeries: dataset.timeSeries.filter((r) => aDayAgo < r.time),
-      name: `${timeSeries.dataset}: ${timeSeries.data_type.long_name}`,
+      name: `${timeSeries.dataset}: ${timeSeries.data_type.long_name} - observations`,
       url: tabledapHtmlUrl(timeSeries.server, timeSeries.dataset, [timeSeries.variable], timeSeries.constraints),
     })
   }
@@ -70,7 +72,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
     if (result?.data) {
       chartData.push({
         timeSeries: result.data as ReadingTimeSeries[],
-        name: meta.name,
+        name: meta.name + " - forecast",
         unit: meta.units,
         url: meta.source_url,
       })
@@ -99,13 +101,10 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
         <ForecastChart type={forecast_type} unitSystem={unitSystem} data={chartData} />
 
         <h6>Data sources</h6>
-        <ul>
-          {chartData.map(({ name, url }) => (
-            <li key={name}>
-              <a href={url}>{name}</a>
-            </li>
-          ))}
-        </ul>
+        <p>
+          For more information on the models and data used in this plot, visit the{" "}
+          <Link to={paths.about}>about page</Link>.
+        </p>
       </Col>
     </Row>
   )

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -1,12 +1,11 @@
 /**
  * Display all time series for a specific standard name
  */
-import * as React from "react"
+import React from "react"
 import { Col, Row } from "reactstrap"
 
 import { LargeTimeSeriesChart } from "components/Charts"
 import { naturalBounds } from "Shared/dataTypes"
-import { tabledapHtmlUrl } from "Shared/erddap/tabledap"
 import { DataTimeSeries } from "Shared/timeSeries"
 import { UnitSystem } from "Features/Units/types"
 import { useUnitSystem } from "Features/Units"
@@ -26,7 +25,7 @@ interface Props {
  * @param platform
  * @param standardName
  */
-export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platform, standardName }) => {
+export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platform, standardName }: Props) => {
   const unitSystem = useUnitSystem()
   const timeSeries = platform.properties.readings.filter((reading) => reading.data_type.standard_name === standardName)
 
@@ -56,7 +55,7 @@ export const ChartTimeSeriesDisplay: React.FunctionComponent<ChartTimeSeriesDisp
   dataset,
   standardName,
   unitSystem,
-}) => {
+}: ChartTimeSeriesDisplayProps) => {
   const depth = timeSeries.depth && timeSeries.depth > 0 ? " at " + timeSeries.depth + "m below" : ""
 
   const bounds = naturalBounds(timeSeries.data_type.standard_name)
@@ -75,15 +74,6 @@ export const ChartTimeSeriesDisplay: React.FunctionComponent<ChartTimeSeriesDisp
           unitSystem={unitSystem}
           data_type={standardName}
         />
-        <p>
-          Data from the {timeSeries.variable} variable in the{" "}
-          <a
-            href={tabledapHtmlUrl(timeSeries.server, timeSeries.dataset, [timeSeries.variable], timeSeries.constraints)}
-          >
-            {timeSeries.dataset} dataset
-          </a>
-          .
-        </p>
       </Col>
     </Row>
   )

--- a/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
@@ -1,13 +1,12 @@
 /**
  * Wind Observed conditions component
  */
-import * as React from "react"
+import React from "react"
 import { Alert, Col, Row } from "reactstrap"
 
 import { WindTimeSeriesChart } from "components/Charts"
 import { useUnitSystem } from "Features/Units"
 import { UnitSystem } from "Features/Units/types"
-import { tabledapHtmlUrl } from "Shared/erddap/tabledap"
 import { DataTimeSeries } from "Shared/timeSeries"
 
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
@@ -27,7 +26,7 @@ interface DisplayProps extends Props {
 /**
  * Wind Observed conditions component
  */
-export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ platform }) => {
+export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ platform }: Props) => {
   const unitSystem = useUnitSystem()
 
   const { timeSeries } = pickWindTimeSeries(platform)
@@ -50,31 +49,14 @@ export const ErddapWindObservedConditionDisplay: React.FunctionComponent<Display
   platform,
   unitSystem,
   datasets,
-}) => {
+}: DisplayProps) => {
   const { speed, gust, direction } = pickWindDatasets(platform, datasets)
-  const { timeSeries } = pickWindTimeSeries(platform)
 
   return (
     <Row>
       <Col>
         <h4>Wind</h4>
         <WindTimeSeriesChart barbsPerDay={5} legend={true} {...{ speed, gust, direction, unitSystem }} />
-        {timeSeries.length > 0 ? (
-          <p>
-            Data from the {timeSeries.map((ts) => ts.variable).join(", ")}{" "}
-            {timeSeries.length > 1 ? "variables" : "variable"} from{" "}
-            <a
-              href={tabledapHtmlUrl(
-                timeSeries[0].server,
-                timeSeries[0].dataset,
-                timeSeries.map((ts) => ts.variable),
-                timeSeries[0].constraints
-              )}
-            >
-              {timeSeries[0].dataset} dataset.
-            </a>
-          </p>
-        ) : null}
       </Col>
     </Row>
   )


### PR DESCRIPTION
forecast or observed is appended to the end of the data type in the legend on forecast charts
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/1296209/110386444-49cdb100-802e-11eb-92a8-2738db20378f.png">

Additionally dataset information is hidden on the chart pages.

Closes #1115 #1116 #1117