### PR TITLE
Change initial bounding box to include Long Island Sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Additions:
 
 Changes:
 
+- Tweak the initial bounding box that the map displays to include Long Island Sound.
+
 Fixes:
 
 ## 0.7.1 - 7/14/2021

--- a/src/Pages/Home/index.tsx
+++ b/src/Pages/Home/index.tsx
@@ -12,7 +12,7 @@ export const HomePage: React.FunctionComponent<{}> = () => {
   return (
     <Row>
       <Col sm={6}>
-        <ErddapMap boundingBox={regions.GulfOfMaine.bbox} height="60vh" />
+        <ErddapMap boundingBox={regions.InitialRegion.bbox} height="60vh" />
         <Superlatives />
       </Col>
       <Col sm={6}>

--- a/src/Shared/regions.ts
+++ b/src/Shared/regions.ts
@@ -3,111 +3,123 @@
  */
 
 export interface BoundingBox {
-    north: number
-    south: number
-    east: number
-    west: number
+  north: number
+  south: number
+  east: number
+  west: number
 }
 
 export interface Region {
-    slug: string
-    name: string
-    bbox: BoundingBox
+  slug: string
+  name: string
+  bbox: BoundingBox
+}
+
+const InitialRegion: Region = {
+  bbox: {
+    east: -65.775,
+    north: 45.125,
+    south: 40.375,
+    west: -73.975,
+  },
+  name: "Initial Region",
+  slug: "initial",
 }
 
 const GulfOfMaine: Region = {
-    bbox: {
-        east:-65.375,
-        north:45.125,
-        south:40.375,
-        west:-70.975,
-    },
-    name: "Gulf Of Maine", 
-    slug: "GOM"
+  bbox: {
+    east: -65.375,
+    north: 45.125,
+    south: 40.375,
+    west: -70.975,
+  },
+  name: "Gulf Of Maine",
+  slug: "GOM",
 }
 
 const LongIslandSound: Region = {
-    bbox: {
-        east: -71.625,
-        north: 41.483,
-        south: 40.697,
-        west: -73.943
-    },
-    name: "Long Island Sound",
-    slug: "LONG"
+  bbox: {
+    east: -71.625,
+    north: 41.483,
+    south: 40.697,
+    west: -73.943,
+  },
+  name: "Long Island Sound",
+  slug: "LONG",
 }
 
 const GreatBay: Region = {
-    bbox: {
-        east: -70.637,
-        north: 43.158,
-        south: 43.012,
-        west: -70.881
-    },
-    name: 'Great Bay, NH',
-    slug: 'GREAT'
+  bbox: {
+    east: -70.637,
+    north: 43.158,
+    south: 43.012,
+    west: -70.881,
+  },
+  name: "Great Bay, NH",
+  slug: "GREAT",
 }
 
 const Boston: Region = {
-    bbox: {
-        east: -70.809,
-        north: 42.443,
-        south: 42.211,
-        west: -71.145
-    },
-    name: 'Boston Harbor',
-    slug: 'BOSTON',
+  bbox: {
+    east: -70.809,
+    north: 42.443,
+    south: 42.211,
+    west: -71.145,
+  },
+  name: "Boston Harbor",
+  slug: "BOSTON",
 }
 
 const CapeCod: Region = {
-    bbox: {
-        east: -69.837,
-        north: 42.108,
-        south: 41.389,
-        west: -71.059
-    },
-    name: 'Cape Cod / Buzzards Bay',
-    slug: 'CAPE'
+  bbox: {
+    east: -69.837,
+    north: 42.108,
+    south: 41.389,
+    west: -71.059,
+  },
+  name: "Cape Cod / Buzzards Bay",
+  slug: "CAPE",
 }
 
 const NarragansettBay: Region = {
-    bbox: {
-        east: -71.060,
-        north: 41.847,
-        south: 41.307,
-        west: -71.564
-    },
-    name: 'Narragansett Bay',
-    slug: 'NARRAGANSETT'
+  bbox: {
+    east: -71.06,
+    north: 41.847,
+    south: 41.307,
+    west: -71.564,
+  },
+  name: "Narragansett Bay",
+  slug: "NARRAGANSETT",
 }
 
 const Newfoundland: Region = {
-    bbox: {
-        east: -52.294,
-        north: 51.835,
-        south: 46.377,
-        west: -59.809
-    },
-    name: 'Newfoundland',
-    slug: 'NEWFOUNDLAND'
+  bbox: {
+    east: -52.294,
+    north: 51.835,
+    south: 46.377,
+    west: -59.809,
+  },
+  name: "Newfoundland",
+  slug: "NEWFOUNDLAND",
 }
 
 export const regions = {
-    Boston,
-    CapeCod,
-    GreatBay,
-    GulfOfMaine,
-    LongIslandSound,
-    NarragansettBay,
-    Newfoundland
+  Boston,
+  CapeCod,
+  GreatBay,
+  GulfOfMaine,
+  InitialRegion,
+  LongIslandSound,
+  NarragansettBay,
+  Newfoundland,
 }
 
 export const regionList: Region[] = [
-    GulfOfMaine,
-    LongIslandSound,
-    GreatBay,
-    Boston,
-    CapeCod,
-    NarragansettBay,
-    Newfoundland
+  GulfOfMaine,
+  LongIslandSound,
+  GreatBay,
+  Boston,
+  CapeCod,
+  NarragansettBay,
+  Newfoundland,
 ]


### PR DESCRIPTION
Adds an initial bounding box that will display Long Island Sound, instead of using the Gulf of Maine bounding box as the starting view.

New view:

![image](https://user-images.githubusercontent.com/1296209/128930310-9c43a26b-59a8-4d8d-802b-86d38eeb563a.png)

Old view:

![image](https://user-images.githubusercontent.com/1296209/128930332-90d83cd4-db34-4479-8a0b-794a4efa11a3.png)


Closes gulfofmaine/NERACOOS-operations#41