### PR TITLE
Revert "Tweaked Docker caching in GitHub Actions"

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,6 +14,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1.5.1
+      
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.6
+        with:
+          path: /tmp/.buildx-cache
+          key: mariners-dashboard-buildx-${{ github.sha }}
+          restore-keys: |
+            mariners-dashboard-buildx-
 
       - name: Cache Docker image
         uses: actions/cache@v2.1.6
@@ -37,9 +45,14 @@ jobs:
           target: develop
           push: false
           tags: gmri/neracoos-mariners-dashboard:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
           outputs: type=docker,dest=/tmp/myimage.tar
+
+      - name: Move Docker Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   unit_tests:
     name: Unit tests, typecheck and coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ Additions:
 
 Changes:
 
-- Tweaked Docker caching in GitHub Actions to use the cache more directly from BuildKit.
-
 Fixes:
 
 ## 0.10.0 - 8/22/2021


### PR DESCRIPTION
Reverts gulfofmaine/Neracoos-1-Buoy-App#1446

Currently failing, may be do to other caching. See: https://github.com/docker/build-push-action/issues/449