### PR TITLE
Remove map tooltip arrow as it is not clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Additions:
 
 Changes:
 
+- Remove arrow from map tooltips/popups as it does not receive click handlers and causes confusion.
+  - Closes [gulfofmaine/NERACOOS-operations#47](https://github.com/gulfofmaine/NERACOOS-operations/issues/47)
+
 Fixes:
 
 ## 0.10.0 - 8/22/2021

--- a/src/components/Map/baseMap.tsx
+++ b/src/components/Map/baseMap.tsx
@@ -207,7 +207,7 @@ export const BaseMap: React.FC<Props> = ({
         style={{ width: "100%", height: height ?? 400, minHeight: 400, maxHeight: "80vh" }}
       />
       <div ref={popupElement} id={POPUP_ID} />
-      <Tooltip isOpen={popupOpen} target={POPUP_ID} toggle={popupClick}>
+      <Tooltip isOpen={popupOpen} target={POPUP_ID} toggle={popupClick} hideArrow={true}>
         <a onClick={popupClick}>{popupText}</a>
       </Tooltip>
     </div>


### PR DESCRIPTION
Closes gulfofmaine/NERACOOS-operations#47