### PR TITLE
Reverting styling changes due to differences between Bootstrap 4 & 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changes:
 
 Fixes:
 
+- Reverting styling changes due to differences between Bootstrap 4 & 5.
+  - On platform pages map and platform info were reversed due to [removal of extra `.order-*`](https://getbootstrap.com/docs/5.1/migration/#grid-updates).
+  - Navbar links lost left justification.
+  - Closes #1590
+
 ## 0.10.1 - 11/9/2021
 
 Changes:

--- a/src/Pages/Platforms/index.tsx
+++ b/src/Pages/Platforms/index.tsx
@@ -32,7 +32,7 @@ export const PlatformsPage: React.FC<RouteComponentProps> = (props: RouteCompone
   return (
     <React.Fragment>
       <Row>
-        <Col sm={{ size: true, order: 6 }}>
+        <Col sm={{ size: true, order: 2 }}>
           <div ref={ref} style={{ marginBottom: ".5rem" }}>
             {/* Show list of platforms in a region if no platform is selected */}
             <Switch>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -39,7 +39,7 @@ export default class NeracoosNavBar extends React.Component<object, State> {
           </NavbarBrand>
           <NavbarToggler onClick={this.toggle} />
 
-          <Collapse isOpen={this.state.isOpen} navbar={true}>
+          <Collapse isOpen={this.state.isOpen} navbar={true} className="justify-content-end">
             <Nav className="ml-auto" navbar={true}>
               <NavLink className="nav-link" activeClassName="active" to={paths.home} exact={true}>
                 Home

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -142,7 +142,7 @@ exports[`Storyshots Components/NavBar Nav Bar 1`] = `
         />
       </button>
       <div
-        className="collapse navbar-collapse"
+        className="justify-content-end collapse navbar-collapse"
         style={Object {}}
       >
         <ul


### PR DESCRIPTION
- On platform pages map and platform info were reversed due to [removal of extra `.order-*`](https://getbootstrap.com/docs/5.1/migration/#grid-updates).
- Navbar links lost left justification.

Closes #1590