### PR TITLE
Fixed TableItems grabbing the wrong data from a single reading

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
@@ -46,6 +46,7 @@ export const ErddapAllObservationsTable: React.FunctionComponent<Props> = ({ pla
             data_type={dataset.data_type.standard_name}
             name={name}
             unitSystem={unitSystem}
+            exact={true}
           />
         )
       })}

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -24,6 +24,8 @@ interface TableItemProps {
   unitSystem: UnitSystem
   /** Show only data later than the selected date */
   later_then?: Date
+  /** The readings have already been filtered, show only the filtered value */
+  exact?: boolean
 }
 
 /**
@@ -36,6 +38,7 @@ export const TableItem: React.FunctionComponent<TableItemProps> = ({
   name,
   unitSystem,
   later_then,
+  exact = false,
 }: TableItemProps) => {
   const [tooltipOpen, setTooltipOpen] = React.useState<boolean>(false)
 
@@ -44,7 +47,7 @@ export const TableItem: React.FunctionComponent<TableItemProps> = ({
   let data: PlatformTimeSeries[] = []
 
   // If there is only one reading specified display that, otherwise filter for the most appropriate one
-  if (readings.length === 1) {
+  if (readings.length === 1 && exact) {
     data = readings
   } else {
     let data_type_list: string[]


### PR DESCRIPTION
Fixed issue when only a single reading is passed to a TableItem that should be filtering by data types.
Closes gulfofmaine/NERACOOS-operations#44 gulfofmaine/NERACOOS-operations#53