### PR TITLE
Select STAC items by collection ID rather than by item ID

### DIFF
--- a/src/Pages/Modeling/index.tsx
+++ b/src/Pages/Modeling/index.tsx
@@ -10,7 +10,7 @@ import { ModelChart } from "./chart"
 import { useCompare, useLayer, usePoint, useTable, useTime, useCurrentItem } from "./query-hooks"
 import { StacCatalogRoot } from "./stac-catalog"
 import { StacMap } from "./stac-map"
-import { useItemsByIdsQuery, useRootCatalogQuery } from "./stac-queries"
+import { useRootCatalogQuery, useLatestItemsByCollectionIdsQuery } from "./stac-queries"
 import { Layer, LoadedData } from "./types"
 import { EdrTable } from "./table"
 
@@ -120,7 +120,7 @@ const ItemsLoader = ({
   point: [number, number]
   // param: string
 }) => {
-  const itemsQuery = useItemsByIdsQuery(layers.map((l) => l.id!))
+  const itemsQuery = useLatestItemsByCollectionIdsQuery(layers.map((l) => l.id!))
 
   const loaded: [IItem, Layer] = itemsQuery
     .map((itemResult, index) => [itemResult, layers[index]] as [UseQueryResult<IItem, Error>, Layer])

--- a/src/Pages/Modeling/stac-catalog.tsx
+++ b/src/Pages/Modeling/stac-catalog.tsx
@@ -286,18 +286,18 @@ const StandardItem = ({ standard_name, item }: { standard_name: string; item: II
       <ButtonGroup>
         <Button
           {...buttonStyle}
-          active={currentLayer.id === item.id && (currentLayer.vars?.includes(key) ?? false)}
+          active={currentLayer.id === item.collection && (currentLayer.vars?.includes(key) ?? false)}
           onClick={() => {
-            setLayer({ id: item.id, vars: [key] })
+            setLayer({ id: item.collection, vars: [key] })
           }}
         >
           Map
         </Button>
         <Button
           {...buttonStyle}
-          active={compareLayers.find((l) => l.id === item.id && l.vars.includes(key)) ? true : false}
+          active={compareLayers.find((l) => l.id === item.collection && l.vars.includes(key)) ? true : false}
           onClick={() => {
-            toggleCompareLayer({ id: item.id, vars: [key] })
+            toggleCompareLayer({ id: item.collection, vars: [key] })
           }}
         >
           Compare

--- a/src/Pages/Modeling/stac-map.tsx
+++ b/src/Pages/Modeling/stac-map.tsx
@@ -8,7 +8,7 @@ import { round } from "Shared/math"
 import { colors } from "Shared/colors"
 
 import { useLayer, useView, usePoint, useTime } from "./query-hooks"
-import { useItemByIdQuery } from "./stac-queries"
+import { useLatestItemByCollectionIdQuery } from "./stac-queries"
 import { initialView } from "./types"
 
 /**
@@ -103,7 +103,7 @@ const SelectedLayerWMS = () => {
  * @param dataVar STAC Item variable to display
  */
 const LayerWMS = ({ layerId, dataVar }: { layerId: string; dataVar: string }) => {
-  const itemQuery = useItemByIdQuery(layerId)
+  const itemQuery = useLatestItemByCollectionIdQuery(layerId)
   const [time, setTime] = useTime()
 
   if (itemQuery.data) {

--- a/src/Pages/Modeling/stac-queries.tsx
+++ b/src/Pages/Modeling/stac-queries.tsx
@@ -65,10 +65,10 @@ async function getLatestItemByCollectionId(catalog: ICatalog, id: string, depth:
   const items = await collection.get_items()
 
   const item = items.reduce((a, b) => {
-    const a_date = new Date(a.properties["cube:dimensions"].forecast_reference_time.values[0])
-    const b_date = new Date(b.properties["cube:dimensions"].forecast_reference_time.values[0])
+    const aDate = new Date(a.properties["cube:dimensions"].forecast_reference_time.values[0])
+    const bDate = new Date(b.properties["cube:dimensions"].forecast_reference_time.values[0])
 
-    if (a_date.valueOf() < b_date.valueOf()) {
+    if (aDate.valueOf() < bDate.valueOf()) {
       return b
     }
     return a


### PR DESCRIPTION
URLs become shorter! http://localhost:3000/models/?compare=%21%28id%7EWW3*_72*_GulfOfMaine%7Evars%7E%21hs%29%28id%7EFVCOM*_GOM3*_Met%7Evars%7E%21wind*_from*_direction%29%7E&view=%28zoom%7E6%7Ecenter%7E%21-68.5%7E43.5%29%7E&layer=%28id%7EFVCOM*_GOM3*_WAVE%7Evars%7E%21hs%29%7E&point=%21-68.94%7E43.81%7E&table=%7E

And they stay relevant!

Closes #2110