### PR TITLE
Redirect buoys with NDBC ID in path and show NDBC ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Additions:
 
 Changes:
 
+- Redirect requests to platforms with NDBC ID in path. Closes [#2171](https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/2171)
+- Show NDBC ID in platform info. Closes [#2171](https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/2171)
 - Use Redux Toolkit.
 
 Fixes:

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -13,23 +13,27 @@ import { UsePlatformRenderProps } from "../../hooks/BuoyBarnComponents"
  * Platform info panel
  * @param platform
  */
-export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => (
-  <Card>
-    <CardBody>
-      <CardTitle>Station {platform.id}</CardTitle>
-      <CardText>
-        {platform.properties.mooring_site_desc}
-        <br />
-        <b>Lat:</b> {round((platform.geometry as Geometry).coordinates[1] as number)} <b>Lon:</b>{" "}
-        {round((platform.geometry as Geometry).coordinates[0] as number)}
-        <br />
-        {platform.properties.attribution.map((attr, key) => (
-          <React.Fragment key={key}>
-            <a href={attr.program.website}>{attr.attribution}</a>
-            <br />
-          </React.Fragment>
-        ))}
-      </CardText>
-    </CardBody>
-  </Card>
-)
+export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
+  const nbdc_site_id = platform.properties.ndbc_site_id ? `${platform.properties.ndbc_site_id} - ` : ""
+  return (
+    <Card>
+      <CardBody>
+        <CardTitle>Station {platform.id}</CardTitle>
+        <CardText>
+          {nbdc_site_id}
+          {platform.properties.mooring_site_desc}
+          <br />
+          <b>Lat:</b> {round((platform.geometry as Geometry).coordinates[1] as number)} <b>Lon:</b>{" "}
+          {round((platform.geometry as Geometry).coordinates[0] as number)}
+          <br />
+          {platform.properties.attribution.map((attr, key) => (
+            <React.Fragment key={key}>
+              <a href={attr.program.website}>{attr.attribution}</a>
+              <br />
+            </React.Fragment>
+          ))}
+        </CardText>
+      </CardBody>
+    </Card>
+  )
+}

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -14,15 +14,20 @@ import { UsePlatformRenderProps } from "../../hooks/BuoyBarnComponents"
  * @param platform
  */
 export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
-  const nbdc_site_id = platform.properties.ndbc_site_id ? `${platform.properties.ndbc_site_id} - ` : ""
+  const nbdc_site_id = platform.properties.ndbc_site_id ? platform.properties.ndbc_site_id : ""
   return (
     <Card>
       <CardBody>
         <CardTitle>Station {platform.id}</CardTitle>
         <CardText>
-          {nbdc_site_id}
           {platform.properties.mooring_site_desc}
           <br />
+          {nbdc_site_id ? (
+            <React.Fragment>
+              <b>NDBC ID:</b> {nbdc_site_id}
+              <br />
+            </React.Fragment>
+          ) : null}
           <b>Lat:</b> {round((platform.geometry as Geometry).coordinates[1] as number)} <b>Lon:</b>{" "}
           {round((platform.geometry as Geometry).coordinates[0] as number)}
           <br />

--- a/src/Pages/Platforms/index.tsx
+++ b/src/Pages/Platforms/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useSearchParams, useLocation, matchPath } from "react-router-dom"
+import { useSearchParams, useLocation, matchPath, useNavigate } from "react-router-dom"
 import { useMeasure } from "react-use"
 import { Col, Row } from "reactstrap"
 
@@ -11,6 +11,7 @@ import { Region } from "Shared/regions"
 import { PlatformInfo } from "./platformInfo"
 import { PlatformTabs } from "./platformTabs"
 import { RootInfo } from "./rootInfo"
+import { urlPartReplacer } from "Shared/urlParams"
 
 /**
  * Top level platform page. Displays region level platform selection if no platform is selected.
@@ -21,12 +22,22 @@ export const PlatformsPage: React.FC = () => {
   // but react-router 6 does not make that as easy,
   // since <Routes> isn't hierarchal like a <Switch>
   const location = useLocation()
+  const navigate = useNavigate()
+  const [ref, { height }] = useMeasure<HTMLDivElement>()
+  let [searchParams, setSearchParams] = useSearchParams()
+
   const match = matchPath({ path: paths.platforms.platform_tailing }, location.pathname)
   const platformId = match?.params.id ?? ""
 
-  const [ref, { height }] = useMeasure<HTMLDivElement>()
+  // Redirect when a 5 character NDBC ID was part of the URL
+  const splitPlatformID = platformId.split(" - ")
+  if (splitPlatformID.length === 2 && splitPlatformID[1].length === 5) {
+    const basePlatformId = splitPlatformID[0]
+    const url = urlPartReplacer(paths.platforms.platform, ":id", basePlatformId)
 
-  let [searchParams, setSearchParams] = useSearchParams()
+    console.log(`Should redirect from ${platformId} to ${basePlatformId}: ${url}`)
+    navigate(url)
+  }
 
   let region: Region | undefined
   const paramsRegion = searchParams.get("region")

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -271,8 +271,13 @@ exports[`Storyshots ERDDAP/Info/Panel Platform Info 1`] = `
     <p
       className="card-text"
     >
-      44037 - 
       Jordan Basin
+      <br />
+      <b>
+        NDBC ID:
+      </b>
+       
+      44037
       <br />
       <b>
         Lat:

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -271,6 +271,7 @@ exports[`Storyshots ERDDAP/Info/Panel Platform Info 1`] = `
     <p
       className="card-text"
     >
+      44037 - 
       Jordan Basin
       <br />
       <b>


### PR DESCRIPTION
If a platform has a NDBC ID it will be shown before the mooring site description.

<img width="870" alt="image" src="https://user-images.githubusercontent.com/1296209/213288730-531a2b16-bcee-4309-9c3b-0f5efd354441.png">

Some tests are likely to fail (and need to get re-setup) until the platforms are adjusted in Buoy Barn to remove the NDBC ID from the platform ID. 

I tested the redirects against a local version of Buoy Barn (hence missing data).

Closes #2171