### PR TITLE
Fix time selector to use latest item 

### DIFF
--- a/src/Pages/Modeling/query-hooks.ts
+++ b/src/Pages/Modeling/query-hooks.ts
@@ -9,7 +9,7 @@ import { round } from "Shared/math"
 
 import { IItem } from "@gulfofmaine/tsstac"
 
-import { useItemByIdQuery } from "./stac-queries"
+import { useLatestItemByCollectionIdQuery } from "./stac-queries"
 import { Layer, initialLayer, initialView } from "./types"
 
 /**
@@ -66,7 +66,7 @@ export function useLayer(): [Layer, (Layer) => void] {
 export function useCurrentItem(): [Layer?, IItem?] {
   const [layer, setLayer] = useLayer()
 
-  const itemQuery = useItemByIdQuery(layer.id ?? "", !!layer.id)
+  const itemQuery = useLatestItemByCollectionIdQuery(layer.id ?? "", !!layer.id)
 
   return [layer, itemQuery.data]
 }

--- a/src/Pages/Modeling/stac-queries.tsx
+++ b/src/Pages/Modeling/stac-queries.tsx
@@ -111,6 +111,9 @@ export async function getItemByUrl(
 /**
  * Load a STAC Item by ID
  *
+ * Probably want to use useLatestItemByCollectionIdQuery as in
+ * most cases the collection ID is used rather than the item ID
+ *
  * @param id ID of STAC Item to load from root catalog
  * @param enabled Should this query be run
  * @returns STAC Item


### PR DESCRIPTION
The time selector was looking for an item ID to match the collection ID, so it needed to get the latest item for a given collection ID instead.

Closes https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/2257