### PR TITLE
Adelle/map zoom bugs

### DIFF
--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -11,7 +11,7 @@ import { RFeature, RLayerVector, RMap, RPopup, RStyle } from "rlayers"
 
 import { colors } from "Shared/colors"
 import { paths } from "Shared/constants"
-import { BoundingBox, regionList, regions } from "Shared/regions"
+import { BoundingBox, InitialRegion, regionList } from "Shared/regions"
 import { urlPartReplacer } from "Shared/urlParams"
 import { EsriOceanBasemapLayer, EsriOceanReferenceLayer } from "components/Map"
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
@@ -122,13 +122,11 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
     if (typeof params.regionId !== "undefined") {
       const regionId = decodeURIComponent(params.regionId)
       const region = regionList.find((r) => r.slug === regionId)
+      console.log(region)
       getView(region)
     }
     if (typeof params.regionId === "undefined") {
-      const keys = Object.keys(regions)
-      console.log(regions)
-      const region = keys.find((region) => regions.InitialRegion.slug === "initial")
-      console.log(region)
+      const region = InitialRegion
       getView(region)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -33,14 +33,10 @@ export interface Props {
 interface BaseProps extends Props {
   // Loaded platforms
   platforms: PlatformFeature[]
-  // // Stateful view to display
-  // view?: RView
-  // // Set stateful view
-  // setView: (view: RView) => void
 }
 
 interface View {
-  center: any
+  center: number[]
   zoom: number
 }
 
@@ -109,7 +105,6 @@ const PlatformLayer = ({ platform, selected, old = false }: PlatformLayerProps) 
 }
 
 // Initial view to display if one is not otherwise set
-// const initial = { center: fromLonLat([-68.5, 43.5]), zoom: 6 }
 const initial = { center: fromLonLat([-68.5, 43.5]), zoom: 6 }
 
 export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, height }: BaseProps) => {

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -109,20 +109,20 @@ const PlatformLayer = ({ platform, selected, old = false }: PlatformLayerProps) 
 }
 
 // Initial view to display if one is not otherwise set
+// const initial = { center: fromLonLat([-68.5, 43.5]), zoom: 6 }
 const initial = { center: fromLonLat([-68.5, 43.5]), zoom: 6 }
 
 export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, height }: BaseProps) => {
   const mapRef = useRef<RMap>(null)
   const params: { regionId?: string } = useParams()
-  const [view, setView] = useState<View>()
+  const [view, setView] = useState<View>(initial)
 
-  //If params change, set bounding box
+  //If params change, set bounding box, then setView to align with map state
   //setView not in deps to avoid rerenders when user zooms
   useEffect(() => {
     if (typeof params.regionId !== "undefined") {
       const regionId = decodeURIComponent(params.regionId)
       const region = regionList.find((r) => r.slug === regionId)
-      console.log(region)
       getView(region)
     }
     if (typeof params.regionId === "undefined") {
@@ -130,7 +130,7 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
       getView(region)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params, platforms, view])
+  }, [params, platforms])
 
   const getView = (region) => {
     const boundingBox = region?.bbox
@@ -138,6 +138,10 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
       const { north, south, east, west } = boundingBox
       const extent = transformExtent([west, south, east, north], "EPSG:4326", "EPSG:3857")
       mapRef?.current?.ol.getView().fit(extent)
+      setView({
+        center: mapRef?.current?.ol.getView().getState().center,
+        zoom: mapRef.current?.ol.getView().getState().zoom || 6,
+      })
     }
   }
 

--- a/src/Shared/regions.ts
+++ b/src/Shared/regions.ts
@@ -15,7 +15,7 @@ export interface Region {
   bbox: BoundingBox
 }
 
-const InitialRegion: Region = {
+export const InitialRegion: Region = {
   bbox: {
     east: -65.775,
     north: 45.125,


### PR DESCRIPTION
This PR seeks to fix a few map bugs that (I believe) were caused by the map state and display not being in sync. 
Issues:
- Inability to zoom manually on map because view was hardcoded (see issue #2683, closes #2683 )
- Region zoom wouldn't work on a hard refresh (ex: a hard refresh on `/region/GREAT` would set map back to initial view)
- Sometime the map wouldn't recognize when the region was changed (this is the corner case where changing regions rapidly would lead to the map view not changing). I've tested this manually several times and I haven't gotten it to break but please test this and let me know if its still breaking for on your end @abkfenris .

The main changes in this branch is taking out the redux handling of the map view and putting it in local state in the `ErddapMapBase` component. From there, when params change, boundingBox is set which triggers a set of the `RMap` view state, which triggers a change in the component's local state, which triggers a rerender of the display in alignment with `RMap`