### PR TITLE
Adelle/mobile map position

### DIFF
--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -29,13 +29,13 @@ export default function Layout({
   return (
     <React.Fragment>
       <Row>
-        <Col sm={{ size: true, order: 2 }}>
+        <Col xs={{ size: "12", order: "2" }} md={{ size: "6", order: "2" }}>
           <div ref={ref} style={{ marginBottom: ".5rem" }}>
             {sidebar}
           </div>
         </Col>
 
-        <Col sm={{ size: true, order: 1 }}>
+        <Col xs={{ size: "12", order: `${isPlatformView ? "2" : "1"}` }} md={{ size: "6", order: "1" }}>
           <ErddapMap height={params.regionId ? "80vh" : height} width="100%" {...(isPlatformView && { platformId })} />
           {belowMap ?? <React.Fragment>{belowMap}</React.Fragment>}
         </Col>

--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -26,6 +26,13 @@ export default function Layout({
     height = 420
   }
 
+  //Removing warning in console re:Highcharts library defaultProps. Not an active warning for us--until this issues is solved on Highcharts' end, keep this to remove huge console error
+  const error = console.error
+  console.error = (...args: any) => {
+    if (/defaultProps/.test(args[0])) return
+    error(...args)
+  }
+
   return (
     <React.Fragment>
       <Row>


### PR DESCRIPTION
This PR adjusts the map positioning depending on the breakpoint and page. Specifically:
- Adjusts break to columns at `md` now so it will be compatible and readable on a tablet
- Adds conditional ordering for `/platform` pages so that map isn't displayed at the top

Mobile Home Page:
<img width="408" alt="Screenshot 2023-11-28 at 11 52 07 AM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/c83335c7-142b-4aac-8e3a-f685f257e193">

Mobile Region Page:
<img width="408" alt="Screenshot 2023-11-28 at 11 52 39 AM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/8fb8c7c9-fb0e-40a7-9579-f9608777e4cc">

Mobile :platformId page:
<img width="405" alt="Screenshot 2023-11-28 at 11 53 03 AM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/5d134156-00b5-4bac-bb71-7511d0919fb9">

All full screen page formats are unchanged.
Some of the mobile views could use some cleaning up in terms of margins and padding but that can be adjusted in another branch.
Closes #2688 

This branch also adds in a spot of code to remove the enormous `defaultProps will be deprecated in the next version` error that clogs up the console. Did some research and its an error within Highcharts that we have no control over until they update their code. For the sake of development, I removed it so the console is clear.