### PR TITLE
Adelle/refresh navigation bug

### DIFF
--- a/app/(platformMap)/@bottom/platform/[platformId]/observations/[standardName]/chart.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/observations/[standardName]/chart.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { ErddapObservedCondition } from "Features/ERDDAP/Platform/Observations/Condition"
 import { UsePlatform } from "Features/ERDDAP/hooks"
+import React from "react"
 
 export function ObservationChart({ platformId, standardName }: { platformId: string; standardName: string }) {
   return (

--- a/app/(platformMap)/@bottom/platform/[platformId]/observations/[standardName]/page.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/observations/[standardName]/page.tsx
@@ -7,9 +7,5 @@ export default function ObservedPlot({
 }: {
   params: { platformId: string; standardName: string }
 }) {
-  return (
-    // <DehydratedPlatforms>
-    <ObservationChart platformId={platformId} standardName={standardName} />
-    // </DehydratedPlatforms>
-  )
+  return <ObservationChart platformId={platformId} standardName={standardName} />
 }

--- a/app/(platformMap)/@bottom/platform/[platformId]/observations/[standardName]/page.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/observations/[standardName]/page.tsx
@@ -1,5 +1,5 @@
-import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
-
+"use client"
+import React from "react"
 import { ObservationChart } from "./chart"
 
 export default function ObservedPlot({
@@ -8,8 +8,8 @@ export default function ObservedPlot({
   params: { platformId: string; standardName: string }
 }) {
   return (
-    <DehydratedPlatforms>
-      <ObservationChart platformId={platformId} standardName={standardName} />
-    </DehydratedPlatforms>
+    // <DehydratedPlatforms>
+    <ObservationChart platformId={platformId} standardName={standardName} />
+    // </DehydratedPlatforms>
   )
 }

--- a/app/(platformMap)/@bottom/platform/[platformId]/observations/wind/chart.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/observations/wind/chart.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { ErddapWindObservedCondition } from "Features/ERDDAP/Platform/Observations/WindCondition"
 import { UsePlatform } from "Features/ERDDAP/hooks"
+import React from "react"
 
 export function WindChart({ platformId }: { platformId: string }) {
   return (

--- a/app/(platformMap)/@bottom/platform/[platformId]/observations/wind/page.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/observations/wind/page.tsx
@@ -1,6 +1,7 @@
 import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
 
 import { WindChart } from "./chart"
+import React from "react"
 
 export default function WindPlot({ params: { platformId } }: { params: { platformId: string } }) {
   return (

--- a/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
+++ b/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
@@ -1,13 +1,21 @@
 import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
-
 import { PlatformInfo } from "Pages/Platforms/platformInfo"
+import React, { useEffect, useState } from "react"
 
 export default async function PlatformSidebar({ params }: { params: { platformId: string } }) {
   const platformId = decodeURIComponent(params.platformId)
+  const [isClient, setIsClient] = useState(false)
 
-  return (
-    <DehydratedPlatforms>
-      <PlatformInfo id={platformId} />
-    </DehydratedPlatforms>
-  )
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  if (isClient) {
+    return (
+      <DehydratedPlatforms>
+        <PlatformInfo id={platformId} />
+      </DehydratedPlatforms>
+    )
+  }
+  return null
 }

--- a/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
+++ b/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
@@ -4,9 +4,5 @@ import React from "react"
 export default async function PlatformSidebar({ params }: { params: { platformId: string } }) {
   const platformId = decodeURIComponent(params.platformId)
 
-  return (
-    // <DehydratedPlatforms>
-    <PlatformInfo id={platformId} />
-    // </DehydratedPlatforms>
-  )
+  return <PlatformInfo id={platformId} />
 }

--- a/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
+++ b/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
@@ -1,21 +1,8 @@
-import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
 import { PlatformInfo } from "Pages/Platforms/platformInfo"
-import React, { useEffect, useState } from "react"
+import React from "react"
 
 export default async function PlatformSidebar({ params }: { params: { platformId: string } }) {
   const platformId = decodeURIComponent(params.platformId)
-  const [isClient, setIsClient] = useState(false)
 
-  useEffect(() => {
-    setIsClient(true)
-  }, [])
-
-  if (isClient) {
-    return (
-      <DehydratedPlatforms>
-        <PlatformInfo id={platformId} />
-      </DehydratedPlatforms>
-    )
-  }
-  return null
+  return <PlatformInfo id={platformId} />
 }

--- a/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
+++ b/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
@@ -4,5 +4,9 @@ import React from "react"
 export default async function PlatformSidebar({ params }: { params: { platformId: string } }) {
   const platformId = decodeURIComponent(params.platformId)
 
-  return <PlatformInfo id={platformId} />
+  return (
+    // <DehydratedPlatforms>
+    <PlatformInfo id={platformId} />
+    // </DehydratedPlatforms>
+  )
 }

--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useParams, usePathname } from "next/navigation"
 import * as React from "react"
+import { useEffect, useState } from "react"
 import { useMeasure } from "react-use"
 import { Col, Row } from "reactstrap"
 import { ErddapMap } from "../../src/Features/ERDDAP/Map"
@@ -21,6 +22,11 @@ export default function Layout({
   const params: { regionId?: string; platformId?: string } = useParams()
   let [ref, { height }] = useMeasure<HTMLDivElement>()
   const platformId = params.platformId
+  const [isClient, setIsClient] = useState(false)
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
 
   if (height < 420) {
     height = 420
@@ -48,7 +54,7 @@ export default function Layout({
         </Col>
       </Row>
 
-      {(isPlatformView && bottom) ?? <Row>{bottom}</Row>}
+      {(isPlatformView && isClient && bottom) ?? <Row>{bottom}</Row>}
     </React.Fragment>
   )
 }

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -170,6 +170,8 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
  * Map that is focused on the Gulf of Maine with the selected platform highlighted
  */
 export const ErddapMap: React.FC<Props> = ({ platformId, height }: Props) => {
+  const path = usePathname()
+  const isPlatformView = path.startsWith("/platform")
   const { isLoading, data } = usePlatforms()
   const [isClient, setIsClient] = useState(false)
 

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import { aDayAgoRounded } from "Shared/time"
 import { useParams } from "next/navigation"
-import { UsePlatforms } from "../hooks"
+import { usePlatforms } from "../hooks"
 import { PlatformFeature } from "../types"
 
 export interface Props {
@@ -170,11 +170,16 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
  * Map that is focused on the Gulf of Maine with the selected platform highlighted
  */
 export const ErddapMap: React.FC<Props> = ({ platformId, height }: Props) => {
-  return (
-    <UsePlatforms>
-      {({ platforms }) => <ErddapMapBase platforms={platforms} platformId={platformId} height={height} />}
-    </UsePlatforms>
-  )
+  const { isLoading, data } = usePlatforms()
+  const [isClient, setIsClient] = useState(false)
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  if (data?.features && isClient) {
+    return <ErddapMapBase platforms={data?.features} platformId={platformId} height={height} />
+  }
 }
 
 /**

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -170,8 +170,6 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
  * Map that is focused on the Gulf of Maine with the selected platform highlighted
  */
 export const ErddapMap: React.FC<Props> = ({ platformId, height }: Props) => {
-  const path = usePathname()
-  const isPlatformView = path.startsWith("/platform")
   const { isLoading, data } = usePlatforms()
   const [isClient, setIsClient] = useState(false)
 

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -180,6 +180,7 @@ export const ErddapMap: React.FC<Props> = ({ platformId, height }: Props) => {
   if (data?.features && isClient) {
     return <ErddapMapBase platforms={data?.features} platformId={platformId} height={height} />
   }
+  return null
 }
 
 /**

--- a/src/formerly_pages/Platforms/platformInfo.tsx
+++ b/src/formerly_pages/Platforms/platformInfo.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useEffect, useState } from "react"
+import React from "react"
 
 import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
 import { ErddapPlatformInfoPanel } from "Features/ERDDAP/Platform/Info"
@@ -17,29 +17,21 @@ import { PlatformMatchParams } from "./types"
 export const PlatformInfo: React.FC<PlatformMatchParams> = ({ id }: PlatformMatchParams) => {
   const unitSystem = useUnitSystem()
   const aDayAgo = aDayAgoRounded()
-  const [isClient, setIsClient] = useState(false)
 
-  useEffect(() => {
-    setIsClient(true)
-  }, [])
-
-  if (isClient) {
-    return (
-      <UsePlatform platformId={id}>
-        {({ platform }) => (
-          <React.Fragment>
-            <PlatformAlerts platform={platform} />
-            <ErddapPlatformInfoPanel platform={platform} />
-            <ErddapObservationTable
-              platform={platform}
-              unitSelector={<UnitSelector />}
-              unitSystem={unitSystem}
-              laterThan={aDayAgo}
-            />
-          </React.Fragment>
-        )}
-      </UsePlatform>
-    )
-  }
-  return null
+  return (
+    <UsePlatform platformId={id}>
+      {({ platform }) => (
+        <React.Fragment>
+          <PlatformAlerts platform={platform} />
+          <ErddapPlatformInfoPanel platform={platform} />
+          <ErddapObservationTable
+            platform={platform}
+            unitSelector={<UnitSelector />}
+            unitSystem={unitSystem}
+            laterThan={aDayAgo}
+          />
+        </React.Fragment>
+      )}
+    </UsePlatform>
+  )
 }

--- a/src/formerly_pages/Platforms/platformInfo.tsx
+++ b/src/formerly_pages/Platforms/platformInfo.tsx
@@ -1,10 +1,10 @@
 "use client"
-import React from "react"
+import React, { useEffect, useState } from "react"
 
+import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
+import { ErddapPlatformInfoPanel } from "Features/ERDDAP/Platform/Info"
 import { ErddapObservationTable } from "Features/ERDDAP/Platform/Observations/Table/table"
 import { UsePlatform } from "Features/ERDDAP/hooks/BuoyBarnComponents"
-import { ErddapPlatformInfoPanel } from "Features/ERDDAP/Platform/Info"
-import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
 
 import { UnitSelector, useUnitSystem } from "Features/Units"
 import { aDayAgoRounded } from "Shared/time"
@@ -16,23 +16,30 @@ import { PlatformMatchParams } from "./types"
  */
 export const PlatformInfo: React.FC<PlatformMatchParams> = ({ id }: PlatformMatchParams) => {
   const unitSystem = useUnitSystem()
-
   const aDayAgo = aDayAgoRounded()
+  const [isClient, setIsClient] = useState(false)
 
-  return (
-    <UsePlatform platformId={id}>
-      {({ platform }) => (
-        <React.Fragment>
-          <PlatformAlerts platform={platform} />
-          <ErddapPlatformInfoPanel platform={platform} />
-          <ErddapObservationTable
-            platform={platform}
-            unitSelector={<UnitSelector />}
-            unitSystem={unitSystem}
-            laterThan={aDayAgo}
-          />
-        </React.Fragment>
-      )}
-    </UsePlatform>
-  )
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  if (isClient) {
+    return (
+      <UsePlatform platformId={id}>
+        {({ platform }) => (
+          <React.Fragment>
+            <PlatformAlerts platform={platform} />
+            <ErddapPlatformInfoPanel platform={platform} />
+            <ErddapObservationTable
+              platform={platform}
+              unitSelector={<UnitSelector />}
+              unitSystem={unitSystem}
+              laterThan={aDayAgo}
+            />
+          </React.Fragment>
+        )}
+      </UsePlatform>
+    )
+  }
+  return null
 }

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test"
+import { expect, test } from "@playwright/test"
 
 /*global cy*/
 
@@ -143,5 +143,41 @@ test.describe("Platfrom 44007", () => {
       .first()
       .click()
     await expect(page.getByText(/Wind Speed:/).first()).toBeVisible()
+  })
+  test("Can perisist observation view on hard refresh", async ({ page }) => {
+    await page.goto(platformUrl)
+    await page
+      .getByText(/Observations/)
+      .first()
+      .click()
+    await page
+      .getByText(/Air Temperature/)
+      .first()
+      .click()
+    await expect(
+      page
+        .locator("h4")
+        .getByText(/Air Temperature/)
+        .first(),
+    ).toBeVisible()
+    await expect(page.getByText(/Data access/).first()).not.toBeVisible()
+    await page.locator("#Tooltip-0").dispatchEvent("mouseover")
+    await expect(page.getByText(/Data access/).first()).toBeVisible()
+    await expect(page.getByText(/Data table/).first()).toBeVisible()
+    await expect(page.getByText(/Download CSV/).first()).toBeVisible()
+    await expect(page.getByText(/ERDDAP dataset/).first()).toBeVisible()
+    await page.reload()
+    await expect(
+      page
+        .locator("h4")
+        .getByText(/Air Temperature/)
+        .first(),
+    ).toBeVisible()
+    await expect(page.getByText(/Data access/).first()).not.toBeVisible()
+    await page.locator("#Tooltip-0").dispatchEvent("mouseover")
+    await expect(page.getByText(/Data access/).first()).toBeVisible()
+    await expect(page.getByText(/Data table/).first()).toBeVisible()
+    await expect(page.getByText(/Download CSV/).first()).toBeVisible()
+    await expect(page.getByText(/ERDDAP dataset/).first()).toBeVisible()
   })
 })

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -169,4 +169,41 @@ test.describe("Platform A01", () => {
       .click()
     await expect(page.getByText(/Sigma-T/).first()).toBeVisible()
   })
+
+  test("Can perisist observation view on hard refresh", async ({ page }) => {
+    await page.goto(platformUrl)
+    await page
+      .getByText(/Observations/)
+      .first()
+      .click()
+    await page
+      .getByText(/Air Temperature/)
+      .first()
+      .click()
+    await expect(
+      page
+        .locator("h4")
+        .getByText(/Air Temperature/)
+        .first(),
+    ).toBeVisible()
+    await expect(page.getByText(/Data access/).first()).not.toBeVisible()
+    await page.locator("#Tooltip-0").dispatchEvent("mouseover")
+    await expect(page.getByText(/Data access/).first()).toBeVisible()
+    await expect(page.getByText(/Data table/).first()).toBeVisible()
+    await expect(page.getByText(/Download CSV/).first()).toBeVisible()
+    await expect(page.getByText(/ERDDAP dataset/).first()).toBeVisible()
+    await page.reload()
+    await expect(
+      page
+        .locator("h4")
+        .getByText(/Air Temperature/)
+        .first(),
+    ).toBeVisible()
+    await expect(page.getByText(/Data access/).first()).not.toBeVisible()
+    await page.locator("#Tooltip-0").dispatchEvent("mouseover")
+    await expect(page.getByText(/Data access/).first()).toBeVisible()
+    await expect(page.getByText(/Data table/).first()).toBeVisible()
+    await expect(page.getByText(/Download CSV/).first()).toBeVisible()
+    await expect(page.getByText(/ERDDAP dataset/).first()).toBeVisible()
+  })
 })

--- a/tests/e2e/Platform/m01.spec.ts
+++ b/tests/e2e/Platform/m01.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test"
+import { expect, test } from "@playwright/test"
 
 const platformUrl = "/platform/M01"
 
@@ -154,5 +154,42 @@ test.describe("Platfrom M01", () => {
       .first()
       .click()
     await expect(page.getByText(/Sigma-T @ 1m/).first()).toBeVisible()
+  })
+
+  test("Can perisist observation view on hard refresh", async ({ page }) => {
+    await page.goto(platformUrl)
+    await page
+      .getByText(/Observations/)
+      .first()
+      .click()
+    await page
+      .getByText(/Air Temperature/)
+      .first()
+      .click()
+    await expect(
+      page
+        .locator("h4")
+        .getByText(/Air Temperature/)
+        .first(),
+    ).toBeVisible()
+    await expect(page.getByText(/Data access/).first()).not.toBeVisible()
+    await page.locator("#Tooltip-0").dispatchEvent("mouseover")
+    await expect(page.getByText(/Data access/).first()).toBeVisible()
+    await expect(page.getByText(/Data table/).first()).toBeVisible()
+    await expect(page.getByText(/Download CSV/).first()).toBeVisible()
+    await expect(page.getByText(/ERDDAP dataset/).first()).toBeVisible()
+    await page.reload()
+    await expect(
+      page
+        .locator("h4")
+        .getByText(/Air Temperature/)
+        .first(),
+    ).toBeVisible()
+    await expect(page.getByText(/Data access/).first()).not.toBeVisible()
+    await page.locator("#Tooltip-0").dispatchEvent("mouseover")
+    await expect(page.getByText(/Data access/).first()).toBeVisible()
+    await expect(page.getByText(/Data table/).first()).toBeVisible()
+    await expect(page.getByText(/Download CSV/).first()).toBeVisible()
+    await expect(page.getByText(/ERDDAP dataset/).first()).toBeVisible()
   })
 })


### PR DESCRIPTION
This addresses https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/2691 where observation and forecast routes were hitting our error page on hard refresh.

Changes made:

Removed DehydratedPlatforms wrapper and added a client check to make sure that components using platform information was the same on client and server.