### PR TITLE
Adelle/models page cleanup

### DIFF
--- a/app/(modelsMap)/models/modeling.tsx
+++ b/app/(modelsMap)/models/modeling.tsx
@@ -111,12 +111,24 @@ export const TableChart = () => {
   } else if (catalogQuery.isLoading) {
     return <div style={{ textAlign: "center" }}>Loading catalog...</div>
   } else if (point) {
-    return <Alert color="warning">Layer needs to be selected to display info for point</Alert>
+    return (
+      <Alert color="warning" style={{ marginLeft: "10px" }}>
+        Layer needs to be selected to display info for point
+      </Alert>
+    )
   } else if (currentLayer.id) {
-    return <Alert color="warning">Point needs to be selected to display info for current layer</Alert>
+    return (
+      <Alert color="warning" style={{ marginLeft: "10px" }}>
+        Point needs to be selected to display info for current layer
+      </Alert>
+    )
   }
 
-  return <Alert color="warning">Select point on map and layer in the sidebar to see info</Alert>
+  return (
+    <Alert color="warning" style={{ marginLeft: "10px" }}>
+      Select point on map and layer in the sidebar to see info
+    </Alert>
+  )
 }
 
 function localWms(url: string) {

--- a/app/(modelsMap)/models/modeling.tsx
+++ b/app/(modelsMap)/models/modeling.tsx
@@ -31,6 +31,7 @@ export const ModelingPage = () => {
           style={{
             padding: "5px",
             border: "1px solid #0000002d",
+            borderRadius: "10px",
           }}
         >
           <StacCatalogRoot />

--- a/app/(modelsMap)/models/modeling.tsx
+++ b/app/(modelsMap)/models/modeling.tsx
@@ -27,7 +27,7 @@ export const ModelingPage = () => {
       <Row style={{ paddingLeft: "10px" }}>
         <Col
           md={3}
-          height="60vh"
+          height="55vh"
           style={{
             padding: "5px",
             border: "1px solid #0000002d",
@@ -40,7 +40,7 @@ export const ModelingPage = () => {
           {!loading && <StacMap />}
         </Col>
       </Row>
-      <Row style={{ padding: "10px", marginTop: "10px" }}>
+      <Row style={{ paddingTop: "10px", marginTop: "10px" }}>
         <TimeControl />
         <TableChart />
       </Row>
@@ -109,7 +109,7 @@ export const TableChart = () => {
       </React.Fragment>
     )
   } else if (catalogQuery.isLoading) {
-    return <div>Loading catalog...</div>
+    return <div style={{ textAlign: "center" }}>Loading catalog...</div>
   } else if (point) {
     return <Alert color="warning">Layer needs to be selected to display info for point</Alert>
   } else if (currentLayer.id) {
@@ -216,7 +216,7 @@ const ItemLayersTabs = ({
   const hourAgo = new Date(now.valueOf() - hourInMlSeconds)
 
   return (
-    <div>
+    <div style={{ marginTop: "10px" }}>
       <Nav tabs={true}>
         <NavItem>
           <NavLink
@@ -239,16 +239,16 @@ const ItemLayersTabs = ({
           </NavLink>
         </NavItem>
       </Nav>
-      <TabContent activeTab={table ? "table" : "chart"}>
+      <TabContent activeTab={table ? "table" : "chart"} style={{ minHeight: "100px", marginTop: "10px" }}>
         <TabPane tabId="chart">
-          {loading || edrLoading ? <div>Loading data...</div> : null}
-          {error || edrError ? <div>Error loading data</div> : null}
+          {loading || edrLoading ? <div style={{ textAlign: "center" }}>Loading data...</div> : null}
+          {error || edrError ? <div style={{ textAlign: "center" }}>Error loading data</div> : null}
           {loaded.length > 0 && <ModelChart loaded={loaded} />}
         </TabPane>
 
         <TabPane tabId="table">
-          {loading || edrLoading ? <div>Loading data...</div> : null}
-          {error || edrError ? <div>Error loading data</div> : null}
+          {loading || edrLoading ? <div style={{ textAlign: "center" }}>Loading data...</div> : null}
+          {error || edrError ? <div style={{ textAlign: "center" }}>Error loading data</div> : null}
           <EdrTable loaded={loaded} after={hourAgo} />
           {/* Table */}
         </TabPane>

--- a/app/(modelsMap)/models/modeling.tsx
+++ b/app/(modelsMap)/models/modeling.tsx
@@ -2,18 +2,18 @@ import { UseQueryResult, useQueries } from "@tanstack/react-query"
 import dynamic from "next/dynamic"
 import React, { useEffect, useState } from "react"
 import Select from "react-select"
-import { Col, Nav, NavItem, NavLink, Row, TabContent, TabPane } from "reactstrap"
+import { Alert, Col, Nav, NavItem, NavLink, Row, TabContent, TabPane } from "reactstrap"
 import { StacCatalogRoot } from "./stac-catalog"
 import { StacMap } from "./stac-map"
 
 import { IAsset, IItem } from "@gulfofmaine/tsstac"
-// import type { DataCubeItem } from "@gulfofmaine/tsstac/extensions/datacube"
-
-const ModelChart = dynamic(() => import("./chart").then((mod) => mod.ModelChart), { ssr: false })
 import { useCompare, useCurrentItem, useLayer, usePoint, useTable, useTime } from "./query-hooks"
 import { useLatestItemsByCollectionIdsQuery, useRootCatalogQuery } from "./stac-queries"
 import { EdrTable } from "./table"
 import { Layer, LoadedData } from "./types"
+// import type { DataCubeItem } from "@gulfofmaine/tsstac/extensions/datacube"
+
+const ModelChart = dynamic(() => import("./chart").then((mod) => mod.ModelChart), { ssr: false })
 
 export const ModelingPage = () => {
   const [loading, setIsLoading] = useState(true)
@@ -24,15 +24,23 @@ export const ModelingPage = () => {
 
   return (
     <>
-      <Row>
-        <Col md={3} style={{ padding: 0 }}>
+      <Row style={{ paddingLeft: "10px" }}>
+        <Col
+          md={3}
+          height="60vh"
+          style={{
+            padding: "5px",
+            border: "1px solid #0000002d",
+            borderRadius: "10px",
+          }}
+        >
           <StacCatalogRoot />
         </Col>
-        <Col md={9} style={{ paddingLeft: 0 }}>
+        <Col md={9} style={{ paddingLeft: "10px" }}>
           {!loading && <StacMap />}
         </Col>
       </Row>
-      <Row>
+      <Row style={{ padding: "10px", marginTop: "10px" }}>
         <TimeControl />
         <TableChart />
       </Row>
@@ -101,14 +109,14 @@ export const TableChart = () => {
       </React.Fragment>
     )
   } else if (catalogQuery.isLoading) {
-    return <div>Loading catalog</div>
+    return <div>Loading catalog...</div>
   } else if (point) {
-    return <div>Layer needs to be selected to display info for point</div>
+    return <Alert color="warning">Layer needs to be selected to display info for point</Alert>
   } else if (currentLayer.id) {
-    return <div>Point needs to be selected to display info for current layer</div>
+    return <Alert color="warning">Point needs to be selected to display info for current layer</Alert>
   }
 
-  return <div>Neither point or layer selected</div>
+  return <Alert color="warning">Select point on map and layer in the sidebar to see info</Alert>
 }
 
 function localWms(url: string) {
@@ -230,15 +238,17 @@ const ItemLayersTabs = ({
             Table
           </NavLink>
         </NavItem>
-        {loading || edrLoading ? <NavItem>Loading</NavItem> : null}
-        {error || edrError ? <NavItem>Error</NavItem> : null}
       </Nav>
       <TabContent activeTab={table ? "table" : "chart"}>
         <TabPane tabId="chart">
-          {loaded.length > 0 ? <ModelChart loaded={loaded} /> : "No data is loaded to display"}
+          {loading || edrLoading ? <div>Loading data...</div> : null}
+          {error || edrError ? <div>Error loading data</div> : null}
+          {loaded.length > 0 && <ModelChart loaded={loaded} />}
         </TabPane>
 
         <TabPane tabId="table">
+          {loading || edrLoading ? <div>Loading data...</div> : null}
+          {error || edrError ? <div>Error loading data</div> : null}
           <EdrTable loaded={loaded} after={hourAgo} />
           {/* Table */}
         </TabPane>

--- a/app/(modelsMap)/models/modeling.tsx
+++ b/app/(modelsMap)/models/modeling.tsx
@@ -31,7 +31,6 @@ export const ModelingPage = () => {
           style={{
             padding: "5px",
             border: "1px solid #0000002d",
-            borderRadius: "10px",
           }}
         >
           <StacCatalogRoot />

--- a/app/(modelsMap)/models/stac-catalog.tsx
+++ b/app/(modelsMap)/models/stac-catalog.tsx
@@ -39,6 +39,7 @@ const STACTraverseBase = ({ catalog }: { catalog: ICatalog }) => {
   const root_children_urls = catalog
     .get_child_links()
     .map((link) => ({ parent: catalog, url: catalog.url_for_link(link) }))
+  console.log(root_children_urls)
 
   return <STACCollectionsLoader catalog={catalog} initial_children_urls={new Set(root_children_urls)} />
 }
@@ -252,10 +253,13 @@ const StandardName = ({ standard_name, items }: { standard_name: string; items: 
         .map((value) => (value as object)["gmri-cube:attrs"].long_name),
     )
     .flat()[0]
+    .toLowerCase()
+
+  const displayName = long_name.charAt(0).toUpperCase() + long_name.slice(1)
 
   return (
     <AccordionItem>
-      <AccordionHeader targetId={standard_name}>{long_name}</AccordionHeader>
+      <AccordionHeader targetId={standard_name}>{displayName}</AccordionHeader>
       <AccordionBody accordionId={standard_name}>
         <ListGroup flush={true}>
           {items.map((item) => {

--- a/app/(modelsMap)/models/stac-catalog.tsx
+++ b/app/(modelsMap)/models/stac-catalog.tsx
@@ -21,7 +21,7 @@ export const StacCatalogRoot = () => {
   const catalogQuery = useRootCatalogQuery()
 
   if (catalogQuery.isLoading) {
-    return <div>Loading model catalog</div>
+    return <div style={{ height: "60vh" }}>Loading model catalog...</div>
   }
 
   if (catalogQuery.data) {
@@ -32,7 +32,7 @@ export const StacCatalogRoot = () => {
     )
   }
 
-  return <div>Error loading root catalog</div>
+  return <div style={{ height: "60vh" }}>Error loading root catalog</div>
 }
 
 const STACTraverseBase = ({ catalog }: { catalog: ICatalog }) => {

--- a/app/(modelsMap)/models/stac-catalog.tsx
+++ b/app/(modelsMap)/models/stac-catalog.tsx
@@ -39,7 +39,6 @@ const STACTraverseBase = ({ catalog }: { catalog: ICatalog }) => {
   const root_children_urls = catalog
     .get_child_links()
     .map((link) => ({ parent: catalog, url: catalog.url_for_link(link) }))
-  console.log(root_children_urls)
 
   return <STACCollectionsLoader catalog={catalog} initial_children_urls={new Set(root_children_urls)} />
 }

--- a/app/(modelsMap)/models/stac-map.tsx
+++ b/app/(modelsMap)/models/stac-map.tsx
@@ -1,14 +1,14 @@
-import "ol/ol.css"
+import { IAsset } from "@gulfofmaine/tsstac"
 import { Point } from "ol/geom"
+import "ol/ol.css"
 import { fromLonLat, toLonLat } from "ol/proj"
 import React from "react"
-import { RMap, RLayerTile, RLayerVector, RFeature, RStyle, RLayerTileWMS } from "rlayers"
-import { IAsset } from "@gulfofmaine/tsstac"
+import { RFeature, RLayerTile, RLayerTileWMS, RLayerVector, RMap, RStyle } from "rlayers"
 
-import { round } from "Shared/math"
 import { colors } from "Shared/colors"
+import { round } from "Shared/math"
 
-import { useLayer, useView, usePoint, useTime } from "./query-hooks"
+import { useLayer, usePoint, useTime, useView } from "./query-hooks"
 import { useLatestItemByCollectionIdQuery } from "./stac-queries"
 import { initialView } from "./types"
 
@@ -21,7 +21,7 @@ export const StacMap = () => {
 
   return (
     <RMap
-      height={"60vh"}
+      height={"65vh"}
       className="model-map"
       initial={{ center: fromLonLat(initialView.center), zoom: initialView.zoom }}
       view={[{ center: fromLonLat(center), zoom }, setView]}

--- a/app/(modelsMap)/models/stac-map.tsx
+++ b/app/(modelsMap)/models/stac-map.tsx
@@ -21,7 +21,7 @@ export const StacMap = () => {
 
   return (
     <RMap
-      height={"65vh"}
+      height={"60vh"}
       className="model-map"
       initial={{ center: fromLonLat(initialView.center), zoom: initialView.zoom }}
       view={[{ center: fromLonLat(center), zoom }, setView]}

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -41,10 +41,10 @@ const NeracoosNavBar = () => {
   const toggle = () => setOpen((open) => !open)
   const close = () => setOpen(false)
 
-  let isMariners = false
+  let isProd = false
 
   if (typeof window !== "undefined") {
-    isMariners = window.location.href.includes("://mariners.neracoos.org")
+    isProd = window.location.href.includes("://mariners.neracoos.org")
   }
 
   return (
@@ -60,7 +60,7 @@ const NeracoosNavBar = () => {
             <NavLink href={paths.home}>Home</NavLink>
 
             <RegionDropdown closeParent={close} />
-            {!isMariners && (
+            {!isProd && (
               <NavItem>
                 <NavLink href={paths.models}>Model Viewer</NavLink>
               </NavItem>


### PR DESCRIPTION
Just threw in a few design edits to the models page:
- Adjusted placement of loading signal so it was in line with what it was loading
- Adjusted loading messages to signal what they were loading
- Compartmentalized the variable selection on the left scrolling sidebar so it was intuitive to scroll
- Adjust spacing generally

Models landing page before:
<img width="1476" alt="Screenshot 2023-12-05 at 4 11 07 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/bbd2b90d-08e5-4db8-9b81-b752b3ec74c2">

Models landing page after:
<img width="1479" alt="Screenshot 2023-12-05 at 4 15 19 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/db241075-cd72-44e4-99c8-fd90b697ee52">

Data loading (bottom) before:
<img width="1478" alt="Screenshot 2023-12-05 at 4 15 51 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/9412f6c2-4edd-4e7e-9ff1-b21dcc67c276">

Data loading (bottom) after:
<img width="1466" alt="Screenshot 2023-12-05 at 4 16 25 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/769b39aa-8973-4dd0-85f3-e82f1d7452be">

