### PR TITLE
patch fix for removing old forecast display

### DIFF
--- a/app/(platformMap)/@bottom/platform/[platformId]/forecast/[standardName]/forecast.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/forecast/[standardName]/forecast.tsx
@@ -1,7 +1,7 @@
 "use client"
+import { Forecast } from "Features/ERDDAP/Platform/Forecasts/Page"
 import { UsePlatform } from "Features/ERDDAP/hooks"
 import { useUnitSystem } from "Features/Units"
-import { Forecast } from "Features/ERDDAP/Platform/Forecasts/Page"
 
 export function ForecastChart({ platformId, standardName }: { platformId: string; standardName: string }) {
   const unitSystem = useUnitSystem()

--- a/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
+++ b/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
@@ -2,24 +2,24 @@
 /**
  * Load and display forecasts
  */
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Point } from "@turf/helpers"
 import React from "react"
-import { Alert, Row, Col, Tooltip } from "reactstrap"
+import { Alert, Col, Row, Tooltip } from "reactstrap"
 
-import { MultipleLargeTimeSeriesChartCurrent } from "components/Charts/MultipleLargeTimeSeriesCurrent"
-import { colorCycle } from "Shared/colors"
-import { round } from "Shared/math"
-import { tabledapHtmlUrl } from "Shared/erddap/tabledap"
-import { aDayAgoRounded } from "Shared/time"
-import { StyledTimeSeries, ReadingTimeSeries } from "Shared/timeSeries"
-import { UnitSystem } from "Features/Units/types"
 import { converter } from "Features/Units/Converter"
+import { UnitSystem } from "Features/Units/types"
+import { colorCycle } from "Shared/colors"
+import { tabledapHtmlUrl } from "Shared/erddap/tabledap"
+import { round } from "Shared/math"
+import { aDayAgoRounded, threeDaysAgoRounded } from "Shared/time"
+import { ReadingTimeSeries, StyledTimeSeries } from "Shared/timeSeries"
+import { MultipleLargeTimeSeriesChartCurrent } from "components/Charts/MultipleLargeTimeSeriesCurrent"
 
+import { useUnitSystem } from "Features/Units"
 import { useDataset, useForecastMeta, useForecasts } from "../../../hooks"
 import { ForecastSource, PlatformFeature, PlatformTimeSeries } from "../../../types"
-import { useUnitSystem } from "Features/Units"
 
 interface Props {
   platform: PlatformFeature
@@ -77,7 +77,6 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
 
   if (dataset && timeSeries) {
     const aDayAgo = aDayAgoRounded()
-
     chartData.push({
       ...dataset,
       timeSeries: dataset.timeSeries.filter((r) => aDayAgo < r.time),
@@ -88,18 +87,24 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
     })
   }
 
-  forecastResults.forEach(({ result, meta }, index) => {
-    if (result?.data) {
-      chartData.push({
-        timeSeries: result.data as ReadingTimeSeries[],
-        name: meta.name + " - forecast",
-        unit: meta.units,
-        url: meta.source_url,
-        dashStyle: "Solid",
-        color: colorCycle[index + 1],
-      })
-    }
-  })
+  forecastResults
+    .filter((r) => {
+      if (r.result.data) {
+        return r.result.data[0].time > threeDaysAgoRounded()
+      }
+    })
+    .forEach(({ result, meta }, index) => {
+      if (result?.data) {
+        chartData.push({
+          timeSeries: result.data as ReadingTimeSeries[],
+          name: meta.name + " - forecast",
+          unit: meta.units,
+          url: meta.source_url,
+          dashStyle: "Solid",
+          color: colorCycle[index + 1],
+        })
+      }
+    })
 
   const unitSystem = useUnitSystem()
 

--- a/src/Shared/time.ts
+++ b/src/Shared/time.ts
@@ -5,6 +5,7 @@
 const HOUR = 1000 * 60 * 60
 const HALF_DAY = HOUR * 12
 const DAY = HOUR * 24
+const THREE_DAYS = DAY * 3
 const WEEK = DAY * 7
 const YEAR = DAY * 365
 
@@ -84,6 +85,14 @@ export function aDayAgoRounded(): Date {
   roundDate(dayAgo)
 
   return dayAgo
+}
+
+export function threeDaysAgoRounded(): Date {
+  const threeDaysAgo = new Date(Date.now() - THREE_DAYS)
+
+  roundDate(threeDaysAgo)
+
+  return threeDaysAgo
 }
 
 /**


### PR DESCRIPTION
This is a patch fix for forecasts displays ([issue #166](https://github.com/gulfofmaine/NERACOOS-operations/issues/166) in Neracoos Operations). Checks to make sure that forecast data is not far in the past. This was fixed in buoy barn already, but these changes can act as another check in case something like this happens again.