### PR TITLE
add dynamic menu items

### DIFF
--- a/src/Features/ERDDAP/Platform/MoreInfoMenu/index.spec.tsx
+++ b/src/Features/ERDDAP/Platform/MoreInfoMenu/index.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import * as React from "react"
 
 import { PlatformFeatureWithDatasets } from "../../types"
 import { ErddapMoreInfoDropdown } from "./index"
@@ -16,7 +16,7 @@ describe("ErddapMoreInfoDropdown", () => {
 
     const dropdownDiv = screen.getAllByRole("menuitem")
 
-    expect(dropdownDiv.length).toEqual(2)
+    expect(dropdownDiv.length).toBeGreaterThan(0)
     expect(dropdownDiv[0]).toContainHTML(wxUrl)
   })
 })

--- a/src/Features/ERDDAP/Platform/MoreInfoMenu/index.tsx
+++ b/src/Features/ERDDAP/Platform/MoreInfoMenu/index.tsx
@@ -1,8 +1,8 @@
 /**
  * Show more info about a platform
  */
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Geometry } from "@turf/helpers"
 import React from "react"
 import { Dropdown, DropdownMenu, DropdownToggle } from "reactstrap"
@@ -37,25 +37,41 @@ export function ErddapMoreInfoDropdown({ platform }: UsePlatformRenderProps) {
       </DropdownToggle>
 
       <DropdownMenu>
+        {platform.properties.links.map((link, index) => (
+          <a
+            className="dropdown-item nav-item"
+            style={{ display: "flex", alignItems: "center" }}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            role="menuitem"
+            key={`dynamic-link-#${index}`}
+          >
+            {link.title}
+            <FontAwesomeIcon icon={faExternalLinkAlt} style={{ width: "12px", marginLeft: ".5rem" }} />
+          </a>
+        ))}
         <a
           className="dropdown-item nav-item"
+          style={{ display: "flex", alignItems: "center" }}
           href={forecastUrl}
           target="_blank"
           rel="noopener noreferrer"
           role="menuitem"
         >
           Marine Forecast
-          <FontAwesomeIcon icon={faExternalLinkAlt} style={{ marginLeft: ".5rem" }} />
+          <FontAwesomeIcon icon={faExternalLinkAlt} style={{ width: "12px", marginLeft: ".5rem" }} />
         </a>
         <a
           className="dropdown-item nav-item"
+          style={{ display: "flex", alignItems: "center" }}
           href="https://tidesandcurrents.noaa.gov/"
           target="_blank"
           rel="noopener noreferrer"
           role="menuitem"
         >
           Tides
-          <FontAwesomeIcon icon={faExternalLinkAlt} style={{ marginLeft: ".5rem" }} />
+          <FontAwesomeIcon icon={faExternalLinkAlt} style={{ width: "12px", marginLeft: ".5rem" }} />
         </a>
       </DropdownMenu>
     </Dropdown>

--- a/src/Features/ERDDAP/Platform/MoreInfoMenu/index.tsx
+++ b/src/Features/ERDDAP/Platform/MoreInfoMenu/index.tsx
@@ -4,7 +4,7 @@
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Geometry } from "@turf/helpers"
-import React from "react"
+import { useEffect, useState } from "react"
 import { Dropdown, DropdownMenu, DropdownToggle } from "reactstrap"
 
 import { UsePlatformRenderProps } from "../../hooks/BuoyBarnComponents"
@@ -19,13 +19,34 @@ type State = Readonly<typeof initialState>
  * Dropdown menu to more info about a platform
  */
 export function ErddapMoreInfoDropdown({ platform }: UsePlatformRenderProps) {
-  const [state, setState] = React.useState<State>(initialState)
+  const [state, setState] = useState<State>(initialState)
+  const [dynamicLinks, setDynamicLinks] = useState()
 
   const toggle = () => {
     setState((currentState) => ({
       dropdownOpen: !currentState.dropdownOpen,
     }))
   }
+
+  useEffect(() => {
+    if (platform) {
+      const links = platform.properties.links?.map((link, index) => (
+        <a
+          className="dropdown-item nav-item"
+          style={{ display: "flex", alignItems: "center" }}
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          role="menuitem"
+          key={`dynamic-link-#${index}`}
+        >
+          {link.title}
+          <FontAwesomeIcon icon={faExternalLinkAlt} style={{ width: "12px", marginLeft: ".5rem" }} />
+        </a>
+      ))
+      setDynamicLinks(links)
+    }
+  }, [platform])
 
   const { coordinates } = platform.geometry as Geometry
   const forecastUrl = `https://marine.weather.gov/MapClick.php?lon=${coordinates[0]}&lat=${coordinates[1]}`
@@ -37,20 +58,7 @@ export function ErddapMoreInfoDropdown({ platform }: UsePlatformRenderProps) {
       </DropdownToggle>
 
       <DropdownMenu>
-        {platform.properties.links.map((link, index) => (
-          <a
-            className="dropdown-item nav-item"
-            style={{ display: "flex", alignItems: "center" }}
-            href={link.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            role="menuitem"
-            key={`dynamic-link-#${index}`}
-          >
-            {link.title}
-            <FontAwesomeIcon icon={faExternalLinkAlt} style={{ width: "12px", marginLeft: ".5rem" }} />
-          </a>
-        ))}
+        {dynamicLinks}
         <a
           className="dropdown-item nav-item"
           style={{ display: "flex", alignItems: "center" }}

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -96,15 +96,9 @@ test.describe("Platfrom 44007", () => {
       .getByText(/More info/)
       .first()
       .click()
-    await expect(
-      page
-        .getByText(/More info/)
-        .first()
-        .locator("..")
-        .locator(":scope > *")
-        .last()
-        .locator(":scope > *"),
-    ).toHaveCount(2)
+
+    const menuItems = await page.getByRole(`menuitem`).all()
+    await expect(menuItems.length).toBeGreaterThan(0)
     await expect(page.getByText(/Marine Forecast/).first()).toBeVisible()
     await expect(page.getByText(/Tides/).first()).toBeVisible()
   })

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test"
+import { expect, test } from "@playwright/test"
 
 /*global cy*/
 
@@ -121,15 +121,8 @@ test.describe("Platform A01", () => {
       .getByText(/More info/)
       .first()
       .click()
-    await expect(
-      page
-        .getByText(/More info/)
-        .first()
-        .locator("..")
-        .locator(":scope > *")
-        .last()
-        .locator(":scope > *"),
-    ).toHaveCount(2)
+    const menuItems = await page.getByRole(`menuitem`).all()
+    await expect(menuItems.length).toBeGreaterThan(0)
     await expect(page.getByText(/Marine Forecast/).first()).toBeVisible()
     await expect(page.getByText(/Tides/).first()).toBeVisible()
   })

--- a/tests/e2e/Platform/m01.spec.ts
+++ b/tests/e2e/Platform/m01.spec.ts
@@ -107,15 +107,8 @@ test.describe("Platfrom M01", () => {
       .getByText(/More info/)
       .first()
       .click()
-    await expect(
-      page
-        .getByText(/More info/)
-        .first()
-        .locator("..")
-        .locator(":scope > *")
-        .last()
-        .locator(":scope > *"),
-    ).toHaveCount(2)
+    const menuItems = await page.getByRole(`menuitem`).all()
+    await expect(menuItems.length).toBeGreaterThan(0)
     await expect(page.getByText(/Marine Forecast/).first()).toBeVisible()
     await expect(page.getByText(/Tides/).first()).toBeVisible()
   })


### PR DESCRIPTION
This adds a dynamic link to the `More Info` tab on the platform view.

Closes frontend portion of #2733 

<img width="1708" alt="Screenshot 2024-01-11 at 4 25 18 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/f70975f4-4c2c-4f92-a851-71a65fa15d8a">
