### PR TITLE
fix water level value bug, make markers bigger, fix base map sensor url

### DIFF
--- a/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
+++ b/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
@@ -71,23 +71,27 @@ export const WLPlatformLayer = ({ platform, selected, old = false }: PlatformLay
 
   let radius: number
   if (selected) {
-    radius = window.innerWidth > adjustPxWidth ? 10 : 15
+    radius = window.innerWidth > adjustPxWidth ? 12 : 17
   } else {
-    radius = window.innerWidth > adjustPxWidth ? 5 : 10
+    radius = window.innerWidth > adjustPxWidth ? 7 : 12
   }
 
   const url = waterLevelSensorPage
     ? `/water-level/sensor/${platform.id}/${getIsoForPicker(threeDaysAgoRounded())}/${getIsoForPicker(
         weeksInFuture(1),
-      )}/${params.datum}`
+      )}/${params.datum ? params.datum : "datum_mllw_meters"}`
     : urlPartReplacer(paths.platforms.platform, ":id", platform.id)
 
   useEffect(() => {
-    const currentWaterLevel = platform.properties.readings.find((r) => r.flood_levels.length)
+    const currentWaterLevel = platform.properties.readings.find(
+      (r) => r.flood_levels.length && r.variable !== "predictedWL",
+    )
     if (!currentWaterLevel) {
       setFloodThreshold("NA")
     } else {
       const value = currentWaterLevel?.value
+      console.log(platform.id, platform.properties.readings)
+      // console.log(platform.id, currentWaterLevel, value, currentWaterLevel.flood_levels)
       const waterLevelThresholds = getWaterLevelThresholdsMapRawComp(currentWaterLevel?.flood_levels)
       const surpassedThreshold = getSurpassedThreshold(value, waterLevelThresholds)
       setFloodThreshold(surpassedThreshold)


### PR DESCRIPTION
Was not able to see this until water levels passed a threshold in real time (i.e. this morning). This fixes a bug that doesn't set the correct value when checking whether WL had passed a certain threshold.

Other thing:
- Increases the size of the map markers a little
- Fixes the url for when a user clicks a sensor from the map in the base url (`/water-level`)

Real time showing that `CASM1` is in Action Level Flood stage as of this morning:
<img width="1693" alt="Screenshot 2024-04-05 at 8 40 21 AM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/26237144-7dde-40bc-97e4-6b6cbc1f77e2">
