### PR TITLE
Use station name for styling when it exists

### DIFF
--- a/src/Features/ERDDAP/List/index.tsx
+++ b/src/Features/ERDDAP/List/index.tsx
@@ -13,6 +13,8 @@ import { BoundingBox } from "Shared/regions"
 import { urlPartReplacer } from "Shared/urlParams"
 
 import { UsePlatforms } from "../hooks"
+import { platformName } from "../utils/platformName"
+import { PlatformFeature } from "../types"
 
 interface Props {
   /** Bounding box to filter platforms by */
@@ -20,7 +22,7 @@ interface Props {
 }
 
 interface BaseProps extends Props {
-  platforms: Feature[]
+  platforms: PlatformFeature[]
 }
 
 /**
@@ -56,7 +58,7 @@ export const ErddapPlatformListBase: React.FC<BaseProps> = ({ boundingBox, platf
               href={urlPartReplacer(paths.platforms.platform, ":id", id as string)}
               className="list-group-item list-group-item-action"
             >
-              {id}
+              {platformName(platform)}
             </Link>
           )
         })

--- a/src/Features/ERDDAP/List/waterSensorList.tsx
+++ b/src/Features/ERDDAP/List/waterSensorList.tsx
@@ -1,15 +1,17 @@
-import { Feature } from "@turf/helpers"
 import { getIsoForPicker, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import { ListGroup } from "reactstrap"
 
+import { platformName } from "../utils/platformName"
+import { PlatformFeature } from "../types"
+
 interface Props {
-  platforms: Feature[]
+  platforms: PlatformFeature[]
 }
 
 export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms }: Props) => {
-  const [sensors, setSensors] = useState<Feature[]>()
+  const [sensors, setSensors] = useState<PlatformFeature[]>()
 
   useEffect(() => {
     if (platforms) {
@@ -38,7 +40,7 @@ export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms }: P
             )}/datum_mllw_meters`}
             className="list-group-item list-group-item-action"
           >
-            {s.id}
+            {platformName(s)}
           </Link>
         ))}
     </ListGroup>

--- a/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
+++ b/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
@@ -27,6 +27,7 @@ import {
   getWaterLevelThresholdsMapRawComp,
 } from "../utils/waterLevelThresholds"
 import { PlatformLayer } from "."
+import { platformName } from "../utils/platformName"
 
 export interface Props {
   // Bounding box for fitting to a region
@@ -142,7 +143,7 @@ const Layer = ({ platform, url, router, radius, color, floodThreshold }) => {
       >
         <RPopup trigger={"hover"}>
           <Button color="dark" size="sm" href={url}>
-            {platform.id} <br></br>Flood level: {floodThreshold ? floodThreshold : "None"}
+            {platformName(platform)} <br></br>Flood level: {floodThreshold ? floodThreshold : "None"}
           </Button>
         </RPopup>
       </RFeature>

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -21,6 +21,7 @@ import { urlPartReplacer } from "Shared/urlParams"
 import { useParams } from "next/navigation"
 import { usePlatforms } from "../hooks"
 import { PlatformFeature } from "../types"
+import { platformName } from "../utils/platformName"
 
 export interface Props {
   // Bounding box for fitting to a region
@@ -100,7 +101,7 @@ export const PlatformLayer = ({ platform, selected, old = false }: PlatformLayer
       >
         <RPopup trigger={"hover"}>
           <Button color="dark" size="sm" href={url}>
-            {platform.id}
+            {platformName(platform)}
           </Button>
         </RPopup>
       </RFeature>

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -8,6 +8,7 @@ import { Card, CardBody, CardText, CardTitle } from "reactstrap"
 import { round } from "Shared/math"
 
 import { UsePlatformRenderProps } from "../../hooks/BuoyBarnComponents"
+import { platformName } from "../../utils/platformName"
 
 /**
  * Platform info panel
@@ -18,7 +19,7 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
   return (
     <Card role="complementary">
       <CardBody>
-        <CardTitle role="header">Station {platform.id}</CardTitle>
+        <CardTitle role="header">Station {platformName(platform)}</CardTitle>
         <CardText>
           {platform.properties.mooring_site_desc}
           <br />

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -13,6 +13,7 @@ import { itemStyle, TableItem } from "./item"
 import { DatumOffsets } from "Features/ERDDAP/types"
 import { usePathname } from "next/navigation"
 import { DatumSelector } from "Features/ERDDAP/waterLevel/DatumSelector"
+import { platformName } from "Features/ERDDAP/utils/platformName"
 
 interface Props extends UsePlatformRenderProps {
   unitSelector?: React.ReactNode
@@ -76,7 +77,7 @@ export const ErddapObservationTable: React.FC<Props> = ({
           })}
         </ListGroupItem>
       ) : (
-        <ListGroupItem style={itemStyle}>There is no recent data from {platform.id}</ListGroupItem>
+        <ListGroupItem style={itemStyle}>There is no recent data from {platformName(platform)}</ListGroupItem>
       )}
 
       <TableItem {...commonProps} data_type={conditions.windSpeed} name="Wind Speed" />

--- a/src/Features/ERDDAP/Superlatives/index.tsx
+++ b/src/Features/ERDDAP/Superlatives/index.tsx
@@ -18,6 +18,7 @@ import { urlPartReplacer } from "Shared/urlParams"
 import { usePlatforms } from "../hooks/buoyBarn"
 import { PlatformFeature, PlatformTimeSeries } from "../types"
 import { conditions } from "../utils/conditions"
+import { platformName } from "../utils/platformName"
 
 const waveHeight = new Set(conditions.waveHeight)
 const windSpeed = new Set(conditions.windSpeed)
@@ -202,9 +203,7 @@ const HighestConditions: React.FunctionComponent<HighestConditionsProps> = ({ pl
         {round(dataConverter.convertToNumber(timeSeries.value!, unitSystem), 1)} {dataConverter.displayName(unitSystem)}
       </div>
       <Link href={url}>
-        <div>
-          {platform.id} - {platform.properties.mooring_site_desc}
-        </div>
+        <div>{platformName(platform)}</div>
       </Link>
     </React.Fragment>
   )

--- a/src/Features/ERDDAP/types.ts
+++ b/src/Features/ERDDAP/types.ts
@@ -29,6 +29,7 @@ export interface PlatformProperties {
   attribution: PlatformAttribution[]
   mooring_site_desc: string
   nbdc_site_id?: string
+  station_name?: string
   // uscg_light_letter?: string
   // watch_circle_radius?: number
 }

--- a/src/Features/ERDDAP/utils/platformName.ts
+++ b/src/Features/ERDDAP/utils/platformName.ts
@@ -1,0 +1,23 @@
+import { Feature } from "@turf/helpers"
+import { PlatformProperties } from "../types"
+
+interface PlatformNameProp extends Pick<PlatformProperties, "station_name"> {}
+
+interface PlatformName extends Feature {
+  id: string
+  properties: PlatformNameProp
+}
+
+/**
+ * Renders the platform name from the slug and the optional specified name in the API
+ * @param platform a subset of platform info
+ */
+export function platformName(platform: PlatformName) {
+  let name = platform.id
+
+  if (platform.properties.station_name && platform.properties.station_name !== "") {
+    name += ": " + platform.properties.station_name
+  }
+
+  return name
+}

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -145,9 +145,7 @@ exports[`Storybook Tests ERDDAP/Superlatives Configurable 1`] = `
             href="/platform/WLIS"
           >
             <div>
-              WLIS
-               - 
-              Western Long Island Sound
+              WLIS: Western Long Island Sound
             </div>
           </a>
         </div>
@@ -166,9 +164,7 @@ exports[`Storybook Tests ERDDAP/Superlatives Configurable 1`] = `
             href="/platform/44008"
           >
             <div>
-              44008
-               - 
-              Nantucket 54NM Southeast of Nantucket
+              44008: Southeast of Nantucket
             </div>
           </a>
         </div>

--- a/src/stories/platforms.ts
+++ b/src/stories/platforms.ts
@@ -3232,6 +3232,7 @@ export const platforms: PlatformFeature[] = [
       uscg_light_num: undefined,
       watch_circle_radius: undefined,
       programs: [6],
+      station_name: "Western Long Island Sound",
     },
   },
   {
@@ -5735,6 +5736,7 @@ export const platforms: PlatformFeature[] = [
       uscg_light_num: undefined,
       watch_circle_radius: undefined,
       programs: [3],
+      station_name: "Southeast of Nantucket",
     },
   },
   {


### PR DESCRIPTION
We now have an optional field `station_name` in the API, so when it's available we should include it in how we display the name of stations, and allow the mooring site description to be a stand alone longer text field.

When a platform has a defined station name it shows both the ID and the name:

<img width="1313" alt="image" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/1296209/4e3b69fb-4c71-4d73-94b8-e8ab854288af">

But it can fall back to just the ID

<img width="1311" alt="image" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/1296209/e4f7f4e9-c2f3-42e8-a666-d8d4f151847d">

Other places with the name displayed:
<img width="1312" alt="image" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/1296209/db6764f6-4130-45e2-b66f-36c32062580d">

<img width="1311" alt="image" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/1296209/54e1c82b-d1f3-45e0-96d9-0898b928e0d3">

<img width="1307" alt="image" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/1296209/4f2be9ae-27ec-4c7b-bc9c-72f99723dad4">

