### PR TITLE
Group redux related updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,12 @@ updates:
         patterns:
           - rlayers
           - ol
+      redux:
+        patterns:
+          - redux-devtools-extension
+          - redux-mock-store
+          - "@reduxjs/toolkit"
+          - "react-redux"
 
   - package-ecosystem: docker
     directory: "/"


### PR DESCRIPTION
Groups react-redux, redux/toolkit, redux-mock-store, and redux-devtools-extension together as some of the updates should be synced.