### PR TITLE
Remove explicit webpack dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,8 +76,7 @@
         "redux-mock-store": "1.5.4",
         "storybook": "^8.0.8",
         "typescript": "^5.4.5",
-        "wait-on": "7.2.0",
-        "webpack": "5"
+        "wait-on": "7.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
     "redux-mock-store": "1.5.4",
     "storybook": "^8.0.8",
     "typescript": "^5.4.5",
-    "wait-on": "7.2.0",
-    "webpack": "5"
+    "wait-on": "7.2.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
We had an old explicit dependency on webpack, but Next should manage the builder/complier dependencies now.