### PR TITLE
fix datum calculation and fix y-axis

### DIFF
--- a/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
@@ -9,6 +9,7 @@ import { LargeTimeSeriesWaterLevelChart } from "./largeTimeSeriesChart"
 import { getDatumDisplayName } from "Shared/dataTypes"
 import { TimeframeSelector } from "../timeframeSelector"
 import { displayShortIso, getIsoForPicker, manuallySetFullEODIso, roundDate, shortIso } from "Shared/time"
+import { round } from "@turf/helpers"
 
 interface ChartTimeSeriesDisplayProps {
   dataset: DataTimeSeries
@@ -41,6 +42,7 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
       return timeSeries.data_type.long_name
     }
   }
+  console.log(dataConverter.convertToNumber(datumOffset as number, unitSystem))
 
   useEffect(() => {
     if (timeSeries.flood_levels.length) {
@@ -49,14 +51,21 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
           acc[level.name] =
             level.name === "Major"
               ? {
-                  minValue: dataConverter.convertToNumber(level.min_value, unitSystem) + datumOffset,
-                  maxValue: dataConverter.convertToNumber(level.min_value, unitSystem) + 1 + datumOffset,
+                  minValue:
+                    dataConverter.convertToNumber(level.min_value, unitSystem) -
+                    dataConverter.convertToNumber(datumOffset, unitSystem),
+                  maxValue:
+                    dataConverter.convertToNumber(level.min_value, unitSystem) +
+                    1 -
+                    dataConverter.convertToNumber(datumOffset, unitSystem),
                 }
               : {
-                  minValue: dataConverter.convertToNumber(level.min_value, unitSystem) + datumOffset,
+                  minValue:
+                    dataConverter.convertToNumber(level.min_value, unitSystem) -
+                    dataConverter.convertToNumber(datumOffset, unitSystem),
                   maxValue:
-                    dataConverter.convertToNumber(timeSeries.flood_levels[index - 1].min_value, unitSystem) +
-                    datumOffset,
+                    dataConverter.convertToNumber(timeSeries.flood_levels[index - 1].min_value, unitSystem) -
+                    dataConverter.convertToNumber(datumOffset, unitSystem),
                 }
         }
         return acc
@@ -93,7 +102,7 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
         predictedTidesTimeSeries={predictedTidesDataset?.timeSeries}
         predictedTidesName={predictedTidesDataset?.name}
         name={title}
-        softMin={-5}
+        softMin={0}
         softMax={{ English: 20, Metric: 10 }}
         unitSystem={unitSystem}
         data_type={standardName}

--- a/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
@@ -74,14 +74,14 @@ export function LargeTimeSeriesWaterLevelChart({
 
   const data = timeSeries.map((r) => [
     r.time.valueOf(),
-    round(dataConverter.convertToNumber(r.reading as number, unitSystem) as number, 2) +
-      (datumOffset ? datumOffset : 0),
+    round(dataConverter.convertToNumber(r.reading as number, unitSystem) as number, 2) -
+      (datumOffset ? round(dataConverter.convertToNumber(datumOffset, unitSystem)) : 0),
   ])
 
   const predictedTidesData = predictedTidesTimeSeries?.map((r) => [
     r.time.valueOf(),
-    round(dataConverter.convertToNumber(r.reading as number, unitSystem) as number, 2) +
-      (datumOffset ? datumOffset : 0),
+    round(dataConverter.convertToNumber(r.reading as number, unitSystem) as number, 2) -
+      (datumOffset ? round(dataConverter.convertToNumber(datumOffset, unitSystem)) : 0),
   ])
 
   return (


### PR DESCRIPTION
This fixes the datum calculation (issue described and updated in issue #2864)

This also fixes the y axis issue where the y-axis was too big for some timeseries (mostly MLLW)

Comparison to Tides&Currents as a test (within rounding error):
<img width="1727" alt="Screenshot 2024-04-23 at 4 22 34 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/0dbcbac7-d72c-4468-a324-409bcb14eefd">

<img width="1724" alt="Screenshot 2024-04-23 at 4 23 16 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/cb61674f-dbb3-45cb-9b04-da9416ec63d1">
