### PR TITLE
Highlighted timeseries

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/all.tsx
@@ -38,17 +38,7 @@ export const ErddapAllObservationsTable: React.FunctionComponent<Props> = ({ pla
         if (dataset.depth) {
           name = name + " @ " + dataset.depth + "m"
         }
-        return (
-          <TableItem
-            key={index}
-            platform={platform}
-            readings={[dataset]}
-            data_type={dataset.data_type.standard_name}
-            name={name}
-            unitSystem={unitSystem}
-            exact={true}
-          />
-        )
+        return <TableItem key={index} platform={platform} timeSeries={dataset} unitSystem={unitSystem} />
       })}
     </ListGroup>
   )

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
@@ -6,66 +6,6 @@ import { UnitSystem } from "Features/Units/types"
 import { PlatformFeature } from "../../../types"
 import { TableItem } from "./item"
 
-describe("TableItem", () => {
-  it("Selectes and renders correct data", () => {
-    render(
-      <TableItem
-        platform={platform}
-        readings={platform.properties.readings}
-        data_type="wind_speed"
-        name="Wind Speed"
-        unitSystem={UnitSystem.english}
-      />,
-    )
-
-    expect(screen.getByRole("link")).toHaveTextContent("Wind Speed:")
-  })
-
-  it("Rounds the wind speed", () => {
-    render(
-      <TableItem
-        platform={platform}
-        readings={platform.properties.readings}
-        data_type="wind_speed"
-        name="Wind Speed"
-        unitSystem={UnitSystem.metric}
-      />,
-    )
-
-    expect(screen.getByRole("link")).toHaveTextContent("Wind Speed: 4.3 Meters/Second")
-  })
-
-  it("Returns null when there is not a matching datatype", () => {
-    render(
-      <TableItem
-        platform={platform}
-        readings={platform.properties.readings}
-        data_type="air_temp"
-        unitSystem={UnitSystem.english}
-        name="Air Temp"
-      />,
-    )
-
-    expect(screen.queryByRole("link")).not.toBeInTheDocument()
-  })
-
-  it("Returns only the first selected datatype", () => {
-    // Need to have a div in the body for the tooltip to attach to
-    render(
-      <TableItem
-        platform={platform}
-        readings={platform.properties.readings}
-        data_type={["significant_wave_height", "significant_height_of_wind_and_swell_waves_3"]}
-        unitSystem={UnitSystem.english}
-        name="Wave Height"
-      />,
-    )
-
-    expect(screen.getByRole("link")).toHaveTextContent("Wave Height: 0.8 Feet")
-    expect(screen.getByRole("link")).not.toHaveTextContent("Wave Height: 1.1 Feet")
-  })
-})
-
 const platform: PlatformFeature = {
   geometry: {
     coordinates: [0, 0],
@@ -143,3 +83,26 @@ const platform: PlatformFeature = {
   },
   type: "Feature",
 }
+
+describe("TableItem", () => {
+  const windSpeed = platform.properties.readings.find((ts) => ts.data_type.standard_name === "wind_speed")
+
+  it("Selectes and renders correct data", () => {
+    render(<TableItem platform={platform} timeSeries={windSpeed} unitSystem={UnitSystem.english} />)
+
+    expect(screen.getByRole("link")).toHaveTextContent("Wind Speed:")
+  })
+
+  it("Rounds the wind speed", () => {
+    render(
+      <TableItem
+        platform={platform}
+        // readings={platform.properties.readings}
+        timeSeries={windSpeed}
+        unitSystem={UnitSystem.metric}
+      />,
+    )
+
+    expect(screen.getByRole("link")).toHaveTextContent("Wind Speed: 4.3 Meters/Second")
+  })
+})

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
@@ -94,14 +94,7 @@ describe("TableItem", () => {
   })
 
   it("Rounds the wind speed", () => {
-    render(
-      <TableItem
-        platform={platform}
-        // readings={platform.properties.readings}
-        timeSeries={windSpeed}
-        unitSystem={UnitSystem.metric}
-      />,
-    )
+    render(<TableItem platform={platform} timeSeries={windSpeed} unitSystem={UnitSystem.metric} />)
 
     expect(screen.getByRole("link")).toHaveTextContent("Wind Speed: 4.3 Meters/Second")
   })

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.stories.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.stories.tsx
@@ -22,22 +22,19 @@ export default {
   },
 }
 
+const windSpeed = platform.properties.readings.find((ts) => ts.data_type.standard_name === "wind_speed")
+
 export const english = (args) => <TableItem {...args} />
 english.args = {
   unitSystem: UnitSystem.english,
-  later_then: new Date("2/3/2020"),
-  data_type: "wind_speed",
-  name: "Wind Speed",
   platform,
-  readings: platform.properties.readings,
+  timeSeries: windSpeed,
 }
 
 export const metric = (args) => <TableItem {...args} />
 metric.args = {
   unitSystem: UnitSystem.metric,
-  later_then: new Date("2/3/2020"),
-  data_type: "wind_speed",
-  name: "Wind Speed",
   platform,
   readings: platform.properties.readings,
+  timeSeries: windSpeed,
 }

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -47,7 +47,7 @@ export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) 
 
   let name = timeSeries.data_type.long_name
   if (timeSeries.depth) {
-    name = `${name} @ ${timeSeries.depth} m`
+    name = `${name} @ ${timeSeries.depth}m`
   }
 
   return (
@@ -66,7 +66,7 @@ export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) 
           id={tooltipId}
         >
           <Sentry.ErrorBoundary fallback={<b>Error displaying {timeSeries.data_type.long_name}</b>} showDialog={false}>
-            <TableItemDisplay name={timeSeries.data_type.long_name} unitSystem={unitSystem} timeSeries={timeSeries} />
+            <TableItemDisplay name={name} unitSystem={unitSystem} timeSeries={timeSeries} />
           </Sentry.ErrorBoundary>
         </span>
       </Link>

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -46,7 +46,7 @@ export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) 
   const tooltipId = `${timeSeries.data_type.standard_name}-tooltip`
 
   let name = timeSeries.data_type.long_name
-  if (timeSeries.depth) {
+  if (timeSeries.depth && timeSeries.depth > 0) {
     name = `${name} @ ${timeSeries.depth}m`
   }
 

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -19,117 +19,68 @@ export const itemStyle = { padding: ".5rem", paddingLeft: "1rem", color: "black"
 
 interface TableItemProps {
   platform: PlatformFeature
-  readings: PlatformTimeSeries[]
-  data_type: string | string[]
-  name: string
+  timeSeries: PlatformTimeSeries
   unitSystem: UnitSystem
-  /** Show only data later than the selected date */
-  later_then?: Date
-  /** The readings have already been filtered, show only the filtered value */
-  exact?: boolean
 }
 
-/**
- * A single item in the current or all conditions tables
- */
-export const TableItem: React.FunctionComponent<TableItemProps> = ({
-  platform,
-  readings,
-  data_type,
-  name,
-  unitSystem,
-  later_then,
-  exact = false,
-}: TableItemProps) => {
-  const [tooltipOpen, setTooltipOpen] = React.useState<boolean>(false)
-
-  const toggleTooltip = () => setTooltipOpen(!tooltipOpen)
-
-  let data: PlatformTimeSeries[] = []
-
-  // If there is only one reading specified display that, otherwise filter for the most appropriate one
-  if (readings.length === 1 && exact) {
-    data = readings
-  } else {
-    let data_type_list: string[]
-
-    if (typeof data_type === "string") {
-      data_type_list = [data_type]
-    } else {
-      data_type_list = data_type
-    }
-
-    data_type_list.forEach((data_type) => {
-      readings
-        .filter((ts) => data_type === ts.data_type.standard_name && (ts.depth ? ts.depth < 2 : true))
-        .forEach((ts) => data.push(ts))
-    })
-  }
-
-  if (data.length > 0) {
-    if (later_then) {
-      data = data.filter((ts) => (ts.time ? later_then < new Date(ts.time) : false))
-    }
-
-    if (data.length === 0) {
-      return <div className="list-group-item">No {name} data received in the last hour</div>
-    }
-
-    const selected = data[0]
-
-    const tooltipId = `${selected.data_type.standard_name}-tooltip`
-
-    return (
-      <React.Fragment>
-        <Link
-          href={urlPartReplacer(
-            urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
-            ":type",
-            selected.data_type.standard_name,
-          )}
-          style={itemStyle}
-          className="list-group-item"
-        >
-          <span
-            // href="#"
-            id={tooltipId}
-          >
-            <Sentry.ErrorBoundary fallback={<b>Error displaying {name}</b>} showDialog={false}>
-              <TableItemDisplay name={name} unitSystem={unitSystem} selected={selected} />
-            </Sentry.ErrorBoundary>
-          </span>
-        </Link>
-        {selected.time ? (
-          <Tooltip
-            className="condition-tooltip"
-            isOpen={tooltipOpen}
-            autohide={false}
-            target={tooltipId}
-            toggle={toggleTooltip}
-          >
-            {new Date(selected.time).toLocaleString()}
-          </Tooltip>
-        ) : null}
-      </React.Fragment>
-    )
-  }
-
-  return null
+type TableItemDisplayProps = Pick<TableItemProps, "timeSeries" | "unitSystem"> & {
+  name: string
 }
 
-type TableItemDisplayProps = Pick<TableItemProps, "name" | "unitSystem"> & {
-  selected: PlatformTimeSeries
-}
+const TableItemDisplay: React.FC<TableItemDisplayProps> = ({ name, unitSystem, timeSeries }: TableItemDisplayProps) => {
+  const unit_converter = converter(timeSeries.data_type.standard_name)
 
-const TableItemDisplay: React.FC<TableItemDisplayProps> = ({ name, unitSystem, selected }: TableItemDisplayProps) => {
-  const unit_converter = converter(selected.data_type.standard_name)
-
-  const value = unit_converter.convertTo(selected.value as number, unitSystem)
+  const value = unit_converter.convertTo(timeSeries.value as number, unitSystem)
 
   return (
     <React.Fragment>
       <b>{name}:</b> {typeof value === "number" ? round(value as number, 1) : value}{" "}
       {unit_converter.displayName(unitSystem)}
+    </React.Fragment>
+  )
+}
+
+export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) => {
+  const [tooltipOpen, setTooltipOpen] = React.useState<boolean>(false)
+  const toggleTooltip = () => setTooltipOpen(!tooltipOpen)
+  const tooltipId = `${timeSeries.data_type.standard_name}-tooltip`
+
+  let name = timeSeries.data_type.long_name
+  if (timeSeries.depth) {
+    name = `${name} @ ${timeSeries.depth} m`
+  }
+
+  return (
+    <React.Fragment>
+      <Link
+        href={urlPartReplacer(
+          urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
+          ":type",
+          timeSeries.data_type.standard_name,
+        )}
+        style={itemStyle}
+        className="list-group-item"
+      >
+        <span
+          // href="#"
+          id={tooltipId}
+        >
+          <Sentry.ErrorBoundary fallback={<b>Error displaying {timeSeries.data_type.long_name}</b>} showDialog={false}>
+            <TableItemDisplay name={timeSeries.data_type.long_name} unitSystem={unitSystem} timeSeries={timeSeries} />
+          </Sentry.ErrorBoundary>
+        </span>
+      </Link>
+      {timeSeries.time ? (
+        <Tooltip
+          className="condition-tooltip"
+          isOpen={tooltipOpen}
+          autohide={false}
+          target={tooltipId}
+          toggle={toggleTooltip}
+        >
+          {new Date(timeSeries.time).toLocaleString()}
+        </Tooltip>
+      ) : null}
     </React.Fragment>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.spec.tsx
@@ -16,7 +16,7 @@ describe("<ErddapObservationTable>", () => {
       />,
     )
 
-    expect(screen.getAllByRole("link").length).toBe(4)
+    expect(screen.getAllByRole("link").length).toBe(3)
     expect(screen.getByRole("list")).toHaveTextContent("Last updated at: ")
     expect(screen.getByRole("list")).toHaveTextContent("Wind Speed: 3.9 Knots")
   })
@@ -30,7 +30,7 @@ describe("<ErddapObservationTable>", () => {
       />,
     )
 
-    expect(screen.getAllByRole("link").length).toBe(4)
+    expect(screen.getAllByRole("link").length).toBe(3)
     expect(screen.getByRole("list")).toHaveTextContent("Last updated at: ")
     expect(screen.getByRole("list")).toHaveTextContent("Wind Speed: 2 Meters/Second")
   })

--- a/src/Features/ERDDAP/types.ts
+++ b/src/Features/ERDDAP/types.ts
@@ -56,6 +56,7 @@ export interface PlatformTimeSeries {
   constraints: {
     [key: string]: string | number
   }
+  highlighted: "No" | "Before" | "After"
 }
 
 export type PlatformDataset = PlatformTimeSeries & {

--- a/src/Features/ERDDAP/utils/currentConditionsTimeseries.spec.ts
+++ b/src/Features/ERDDAP/utils/currentConditionsTimeseries.spec.ts
@@ -2,41 +2,41 @@ import { currentConditionsTimeseries } from "./currentConditionsTimeseries"
 import { platform } from "../../../stories/platform"
 
 describe("currentConditionsTimeseries", () => {
-    const laterThan = new Date("2020-02-03")
+  const laterThan = new Date("2020-02-03")
 
-    it("Finds wind timeseries", () => {
-        const { windTimeSeries } = currentConditionsTimeseries(platform, laterThan)
-        const windTimeSeriesVariables = windTimeSeries.map((ts) => ts.variable)
+  it("Finds wind timeseries", () => {
+    const { windTimeSeries } = currentConditionsTimeseries(platform, laterThan)
+    const windTimeSeriesVariables = windTimeSeries.map((ts) => ts.variable)
 
-        expect(windTimeSeriesVariables).toStrictEqual(["wind_speed", "wind_gust", "wind_direction"])
-    })
+    expect(windTimeSeriesVariables).toStrictEqual(["wind_speed", "wind_gust", "wind_direction"])
+  })
 
-    it("Finds timeseries that should go before normal selection", () => {
-        const { before } = currentConditionsTimeseries(platform, laterThan)
-        const beforeVariables = before.map((ts) => ts.variable)
+  it("Finds timeseries that should go before normal selection", () => {
+    const { before } = currentConditionsTimeseries(platform, laterThan)
+    const beforeVariables = before.map((ts) => ts.variable)
 
-        expect(beforeVariables).toStrictEqual(["significant_wave_height_3", "air_temperature"])
-    })
+    expect(beforeVariables).toStrictEqual(["significant_wave_height_3", "air_temperature"])
+  })
 
-    it("Finds timeseries that should go after normal selection", () => {
-        const { after } = currentConditionsTimeseries(platform, laterThan)
-        const afterVariables = after.map((ts) => ts.variable)
+  it("Finds timeseries that should go after normal selection", () => {
+    const { after } = currentConditionsTimeseries(platform, laterThan)
+    const afterVariables = after.map((ts) => ts.variable)
 
-        expect(afterVariables).toStrictEqual(["temperature", "dominant_wave_period_3"])
-    })
+    expect(afterVariables).toStrictEqual(["temperature", "dominant_wave_period_3"])
+  })
 
-    it("Normal selection should not include highlighted variables", () => {
-        const { timeSeries } = currentConditionsTimeseries(platform, laterThan)
-        const timeSeriesVariables = timeSeries.map((ts) => ts.variable)
+  it("Normal selection should not include highlighted variables", () => {
+    const { timeSeries } = currentConditionsTimeseries(platform, laterThan)
+    const timeSeriesVariables = timeSeries.map((ts) => ts.variable)
 
-        expect(timeSeriesVariables).not.toContain("temperature")
-        expect(timeSeriesVariables).not.toContain("air_temperature")
-    })
+    expect(timeSeriesVariables).not.toContain("temperature")
+    expect(timeSeriesVariables).not.toContain("air_temperature")
+  })
 
-    it("A group of normal variables should be selected", () => {
-        const {timeSeries } = currentConditionsTimeseries(platform, laterThan)
-        const timeSeriesVariables = timeSeries.map((ts) => ts.variable)
+  it("A group of normal variables should be selected", () => {
+    const { timeSeries } = currentConditionsTimeseries(platform, laterThan)
+    const timeSeriesVariables = timeSeries.map((ts) => ts.variable)
 
-        expect(timeSeriesVariables).toStrictEqual(["barometric_pressure", "visibility"])
-    })
+    expect(timeSeriesVariables).toStrictEqual(["barometric_pressure", "visibility"])
+  })
 })

--- a/src/Features/ERDDAP/utils/currentConditionsTimeseries.spec.ts
+++ b/src/Features/ERDDAP/utils/currentConditionsTimeseries.spec.ts
@@ -1,0 +1,42 @@
+import { currentConditionsTimeseries } from "./currentConditionsTimeseries"
+import { platform } from "../../../stories/platform"
+
+describe("currentConditionsTimeseries", () => {
+    const laterThan = new Date("2020-02-03")
+
+    it("Finds wind timeseries", () => {
+        const { windTimeSeries } = currentConditionsTimeseries(platform, laterThan)
+        const windTimeSeriesVariables = windTimeSeries.map((ts) => ts.variable)
+
+        expect(windTimeSeriesVariables).toStrictEqual(["wind_speed", "wind_gust", "wind_direction"])
+    })
+
+    it("Finds timeseries that should go before normal selection", () => {
+        const { before } = currentConditionsTimeseries(platform, laterThan)
+        const beforeVariables = before.map((ts) => ts.variable)
+
+        expect(beforeVariables).toStrictEqual(["significant_wave_height_3", "air_temperature"])
+    })
+
+    it("Finds timeseries that should go after normal selection", () => {
+        const { after } = currentConditionsTimeseries(platform, laterThan)
+        const afterVariables = after.map((ts) => ts.variable)
+
+        expect(afterVariables).toStrictEqual(["temperature", "dominant_wave_period_3"])
+    })
+
+    it("Normal selection should not include highlighted variables", () => {
+        const { timeSeries } = currentConditionsTimeseries(platform, laterThan)
+        const timeSeriesVariables = timeSeries.map((ts) => ts.variable)
+
+        expect(timeSeriesVariables).not.toContain("temperature")
+        expect(timeSeriesVariables).not.toContain("air_temperature")
+    })
+
+    it("A group of normal variables should be selected", () => {
+        const {timeSeries } = currentConditionsTimeseries(platform, laterThan)
+        const timeSeriesVariables = timeSeries.map((ts) => ts.variable)
+
+        expect(timeSeriesVariables).toStrictEqual(["barometric_pressure", "visibility"])
+    })
+})

--- a/src/Features/ERDDAP/utils/currentConditionsTimeseries.ts
+++ b/src/Features/ERDDAP/utils/currentConditionsTimeseries.ts
@@ -1,0 +1,77 @@
+import { conditions } from "./conditions"
+import { PlatformFeature, PlatformTimeSeries } from "../types"
+import { pickWindTimeSeries } from "./wind"
+
+export function filterTimeSeries(timeSeries: PlatformTimeSeries[], dataTypes: string[], laterThan: Date) {
+  let filterTimeSeries: PlatformTimeSeries[] = []
+
+  dataTypes.forEach((dataType) => {
+    const matchStandard = timeSeries.filter((reading) => dataType === reading.data_type.standard_name) // match any that are the current data type
+    const matchTime = matchStandard.filter((reading) => (reading.time ? laterThan < new Date(reading.time) : false)) // that have data in the last day
+    const matchDepth = matchTime.filter((reading) => (reading.depth ? reading.depth < 2 : true)) // are near-surface
+    matchDepth.forEach((ts) => filterTimeSeries.push(ts))
+  })
+
+  if (filterTimeSeries.length > 0) {
+    return filterTimeSeries[0]
+  }
+
+  return null
+}
+
+
+/**
+ * Filters timeseries that should be displayed on current conditions page or in sidebar.
+ * They are grouped by timeseries that are manually selected to before or after the normal set of conditions,
+ * the wind timeseries, and the remaining selection with those three groups filtered out.
+ * 
+ * Additionally return all of the filtered timeseries
+ * @param platform 
+ * @param laterThan 
+ * @returns 
+ */
+export function currentConditionsTimeseries(platform: PlatformFeature, laterThan: Date) {
+  const before = platform.properties.readings.filter((ts) => ts.highlighted === "Before")
+  const after = platform.properties.readings.filter((ts) => ts.highlighted === "After")
+
+  const notHighlighted = platform.properties.readings.filter((ts) => ts.highlighted === "No")
+
+  const airTemp = filterTimeSeries(notHighlighted, conditions.airTemp, laterThan)
+  const airPressure = filterTimeSeries(notHighlighted, conditions.airPressure, laterThan)
+  const waveHeight = filterTimeSeries(notHighlighted, conditions.waveHeight, laterThan)
+  const wavePeriod = filterTimeSeries(notHighlighted, conditions.wavePeriod, laterThan)
+  const waveDirection = filterTimeSeries(notHighlighted, conditions.waveDirection, laterThan)
+  const waterTemp = filterTimeSeries(notHighlighted, conditions.waterTemp, laterThan)
+  const waterLevel = filterTimeSeries(notHighlighted, conditions.waterLevel, laterThan)
+  const visibility = filterTimeSeries(notHighlighted, conditions.visibility, laterThan)
+
+  const {timeSeries: windTimeSeries } = pickWindTimeSeries(platform, laterThan)
+
+  const timeSeriesWithNull = [
+    waveHeight,
+    wavePeriod,
+    waveDirection,
+    airPressure,
+    airTemp,
+    waterTemp,
+    waterLevel,
+    visibility,
+  ]
+  const timeSeries = timeSeriesWithNull.filter((ts) => ts !== null) as PlatformTimeSeries[]
+
+  const allWithNull = [
+    ...before,
+    ...windTimeSeries,
+    ...timeSeries,
+    ...after
+  ]
+  const allCurrentConditionsTimeseries = allWithNull.filter((ts) => ts !== null) as PlatformTimeSeries[]
+
+  return {
+    before,
+    after,
+    windTimeSeries,
+    timeSeries,
+    allCurrentConditionsTimeseries
+  }
+}

--- a/src/Features/ERDDAP/utils/currentConditionsTimeseries.ts
+++ b/src/Features/ERDDAP/utils/currentConditionsTimeseries.ts
@@ -19,16 +19,15 @@ export function filterTimeSeries(timeSeries: PlatformTimeSeries[], dataTypes: st
   return null
 }
 
-
 /**
  * Filters timeseries that should be displayed on current conditions page or in sidebar.
  * They are grouped by timeseries that are manually selected to before or after the normal set of conditions,
  * the wind timeseries, and the remaining selection with those three groups filtered out.
- * 
+ *
  * Additionally return all of the filtered timeseries
- * @param platform 
- * @param laterThan 
- * @returns 
+ * @param platform
+ * @param laterThan
+ * @returns
  */
 export function currentConditionsTimeseries(platform: PlatformFeature, laterThan: Date) {
   const before = platform.properties.readings.filter((ts) => ts.highlighted === "Before")
@@ -45,7 +44,7 @@ export function currentConditionsTimeseries(platform: PlatformFeature, laterThan
   const waterLevel = filterTimeSeries(notHighlighted, conditions.waterLevel, laterThan)
   const visibility = filterTimeSeries(notHighlighted, conditions.visibility, laterThan)
 
-  const {timeSeries: windTimeSeries } = pickWindTimeSeries(platform, laterThan)
+  const { timeSeries: windTimeSeries } = pickWindTimeSeries(platform, laterThan)
 
   const timeSeriesWithNull = [
     waveHeight,
@@ -59,12 +58,7 @@ export function currentConditionsTimeseries(platform: PlatformFeature, laterThan
   ]
   const timeSeries = timeSeriesWithNull.filter((ts) => ts !== null) as PlatformTimeSeries[]
 
-  const allWithNull = [
-    ...before,
-    ...windTimeSeries,
-    ...timeSeries,
-    ...after
-  ]
+  const allWithNull = [...before, ...windTimeSeries, ...timeSeries, ...after]
   const allCurrentConditionsTimeseries = allWithNull.filter((ts) => ts !== null) as PlatformTimeSeries[]
 
   return {
@@ -72,6 +66,6 @@ export function currentConditionsTimeseries(platform: PlatformFeature, laterThan
     after,
     windTimeSeries,
     timeSeries,
-    allCurrentConditionsTimeseries
+    allCurrentConditionsTimeseries,
   }
 }

--- a/src/stories/platform.ts
+++ b/src/stories/platform.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
-import { PlatformFeatureWithDatasets } from "Features/ERDDAP/types"
+import { PlatformFeatureWithDatasets, PlatformFeature } from "Features/ERDDAP/types"
 import { forecastToStandardNames } from "Features/ERDDAP/Platform/Forecasts/Page"
 
-const platform_base = {
+const platform_base: PlatformFeature = {
   id: "M01",
   type: "Feature",
   geometry: {
@@ -32,6 +32,7 @@ const platform_base = {
         error: "",
         loadStartTimes: [],
         loading: false,
+        highlighted: "No",
         readings: [
           {
             reading: 4.55,
@@ -149,6 +150,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 33.9589462280273,
@@ -172,6 +174,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 9.89000034332275,
@@ -195,6 +198,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 25.5368404388428,
@@ -218,6 +222,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 32.5026893615723,
@@ -241,6 +246,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 6.34700012207031,
@@ -264,6 +270,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 25.2565860748291,
@@ -287,6 +294,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 31.966287612915,
@@ -310,6 +318,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 30.9360008239746,
@@ -333,6 +342,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 32.4659996032715,
@@ -356,6 +366,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 37.0120010375977,
@@ -379,6 +390,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 290.853210449219,
@@ -401,6 +413,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 1.39300000667572,
@@ -422,6 +435,7 @@ const platform_base = {
         error: "",
         loadStartTimes: [],
         loading: false,
+        highlighted: "Before",
         readings: [
           {
             reading: 2.85,
@@ -538,6 +552,7 @@ const platform_base = {
         loadStartTimes: [],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 5.13100004196167,
@@ -560,6 +575,7 @@ const platform_base = {
         error: "",
         loadStartTimes: [new Date("2020-01-28T14:18:01.570Z")],
         loading: false,
+        highlighted: "After",
         readings: [
           {
             reading: 5.92,
@@ -1919,6 +1935,7 @@ const platform_base = {
         error: "",
         loadStartTimes: ["2020-01-28T14:18:01.570Z"],
         loading: false,
+        highlighted: "After",
         readings: [
           {
             reading: 5,
@@ -2602,6 +2619,7 @@ const platform_base = {
         error: "",
         loadStartTimes: ["2020-01-28T14:18:01.570Z"],
         loading: false,
+        highlighted: "Before",
         readings: [
           {
             reading: 0.696,
@@ -6629,6 +6647,7 @@ const platform_base = {
         error: "",
         loadStartTimes: ["2020-01-28T14:18:01.570Z"],
         loading: false,
+        highlighted: "No",
         readings: [
           {
             reading: 2977.7466,
@@ -10654,6 +10673,7 @@ const platform_base = {
         error: "",
         loadStartTimes: ["2020-01-28T14:18:01.570Z"],
         loading: false,
+        highlighted: "No",
         readings: [
           {
             reading: 355.92,
@@ -14679,6 +14699,7 @@ const platform_base = {
         error: "",
         loadStartTimes: ["2020-01-28T14:18:01.570Z"],
         loading: false,
+        highlighted: "No",
         readings: [
           {
             reading: 8.46,
@@ -18706,6 +18727,7 @@ const platform_base = {
         error: "",
         loadStartTimes: ["2020-01-28T14:18:01.570Z"],
         loading: false,
+        highlighted: "No",
         readings: [
           {
             reading: 1004.6906,
@@ -22731,6 +22753,7 @@ const platform_base = {
         loadStartTimes: ["2020-01-28T14:18:01.570Z"],
         loading: false,
         readings: [],
+        highlighted: "No",
       },
       {
         value: 3.33200001716614,
@@ -22750,6 +22773,7 @@ const platform_base = {
         error: "",
         loadStartTimes: ["2020-01-28T14:20:13.209Z"],
         loading: false,
+        highlighted: "No",
         readings: [
           {
             reading: 10.31,

--- a/src/stories/platforms.ts
+++ b/src/stories/platforms.ts
@@ -30,6 +30,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 12.8000001907349,
@@ -50,6 +51,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.59999990463257,
@@ -70,6 +72,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 270,
@@ -90,6 +93,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 23.8999996185303,
@@ -110,6 +114,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.59999990463257,
@@ -130,6 +135,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -180,6 +186,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1007,
@@ -200,6 +207,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 12.3000001907349,
@@ -220,6 +228,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2,
@@ -240,6 +249,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -1.70000004768372,
@@ -260,6 +270,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.59999990463257,
@@ -280,6 +291,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 26.2999992370605,
@@ -300,6 +312,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -4,
@@ -320,6 +333,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -370,6 +384,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14.1000003814697,
@@ -390,6 +405,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1.5,
@@ -410,6 +426,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 21,
@@ -430,6 +447,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -4,
@@ -450,6 +468,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -501,6 +520,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 95,
@@ -521,6 +541,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 15.3999996185303,
@@ -542,6 +563,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13,
@@ -563,6 +585,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1.39999997615814,
@@ -583,6 +606,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -633,6 +657,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 310,
@@ -653,6 +678,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4,
@@ -673,6 +699,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13.6000003814697,
@@ -693,6 +720,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.600000023841858,
@@ -714,6 +742,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5,
@@ -734,6 +763,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 3.09999990463257,
@@ -754,6 +784,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7.19999980926514,
@@ -775,6 +806,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -2.59999990463257,
@@ -795,6 +827,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13,
@@ -816,6 +849,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 103,
@@ -836,6 +870,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1004.5,
@@ -857,6 +892,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 19.8999996185303,
@@ -878,6 +914,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 16.3999996185303,
@@ -899,6 +936,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -949,6 +987,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2999.3720703125,
@@ -969,6 +1008,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7.09499979019165,
@@ -987,6 +1027,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.11100006103516,
@@ -1005,6 +1046,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.4083671569824,
@@ -1026,6 +1068,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.5865707397461,
@@ -1047,6 +1090,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.4281005859375,
@@ -1068,6 +1112,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.990400016307831,
@@ -1088,6 +1133,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-29T19:13:14Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1.58270001411438,
@@ -1108,6 +1154,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-29T19:13:50Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 281.700012207031,
@@ -1126,6 +1173,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 19.9444007873535,
@@ -1146,6 +1194,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 38.6580009460449,
@@ -1167,6 +1216,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 266.383209228516,
@@ -1187,6 +1237,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4,
@@ -1207,6 +1258,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-01-08T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1003.24731445312,
@@ -1227,6 +1279,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T12:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.9406394958496,
@@ -1248,6 +1301,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 36.4113998413086,
@@ -1269,6 +1323,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.3133850097656,
@@ -1290,6 +1345,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 38.0896987915039,
@@ -1310,6 +1366,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13.4460000991821,
@@ -1331,6 +1388,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 12.8339996337891,
@@ -1352,6 +1410,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.4188423156738,
@@ -1373,6 +1432,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10.7512998580933,
@@ -1394,6 +1454,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T02:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -1482,6 +1543,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-23T17:14:27Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5.09999990463257,
@@ -1503,6 +1565,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-08-21T17:56:25Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 120,
@@ -1524,6 +1587,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-23T17:15:40Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13,
@@ -1545,6 +1609,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-23T17:15:24Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1.39999997615814,
@@ -1566,6 +1631,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-23T17:14:56Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -1617,6 +1683,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 38.1357002258301,
@@ -1638,6 +1705,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.620599985122681,
@@ -1658,6 +1726,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-29T19:15:44Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.2595310211182,
@@ -1679,6 +1748,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.2566375732422,
@@ -1700,6 +1770,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.1930751800537,
@@ -1721,6 +1792,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 30.2813415527344,
@@ -1742,6 +1814,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 39.8199996948242,
@@ -1763,6 +1836,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.0648250579834,
@@ -1784,6 +1858,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 31.7215747833252,
@@ -1805,6 +1880,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 36.5200004577637,
@@ -1826,6 +1902,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-08T00:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5.39599990844727,
@@ -1844,6 +1921,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2000-07-10T19:00:02Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.8600001335144,
@@ -1862,6 +1940,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2000-07-10T19:00:02Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 999.19775390625,
@@ -1882,6 +1961,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2000-07-10T19:00:02Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 322.100006103516,
@@ -1900,6 +1980,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2000-07-10T19:00:02Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 19.9400005340576,
@@ -1920,6 +2001,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2000-07-10T19:00:02Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.419715642929077,
@@ -1940,6 +2022,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-01-08T17:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6,
@@ -1960,6 +2043,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-01-08T17:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -2011,6 +2095,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-29T19:06:36Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 31.7164306640625,
@@ -2032,6 +2117,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T04:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.74499797821045,
@@ -2052,6 +2138,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-28T06:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.1159999370575,
@@ -2072,6 +2159,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-29T19:06:07Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 74.2200012207031,
@@ -2092,6 +2180,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2008-10-01T15:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 23.2709121704102,
@@ -2113,6 +2202,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T04:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 15.7898998260498,
@@ -2133,6 +2223,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2008-10-01T15:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 15.7898998260498,
@@ -2154,6 +2245,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T04:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.24539041519165,
@@ -2174,6 +2266,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-03-09T00:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 30.4813995361328,
@@ -2195,6 +2288,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T04:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.9666233062744,
@@ -2216,6 +2310,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T04:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.74469375610352,
@@ -2236,6 +2331,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2008-10-01T15:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.94079804420471,
@@ -2256,6 +2352,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-28T06:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 31.5807323455811,
@@ -2277,6 +2374,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T04:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 40.0124015808105,
@@ -2298,6 +2396,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T04:34:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 43.5996894836426,
@@ -2318,6 +2417,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-28T06:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 20.5499992370605,
@@ -2338,6 +2438,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T03:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4.92199993133545,
@@ -2356,6 +2457,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T03:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 33.4486999511719,
@@ -2376,6 +2478,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-28T06:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 297.299987792969,
@@ -2394,6 +2497,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T03:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2923.68310546875,
@@ -2414,6 +2518,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T03:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5.0059118270874,
@@ -2434,6 +2539,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2008-10-01T15:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1003.22497558594,
@@ -2454,6 +2560,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T03:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.66400003433228,
@@ -2472,6 +2579,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-10T03:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10,
@@ -2492,6 +2600,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-03-09T00:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -2543,6 +2652,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -0.800000011920929,
@@ -2563,6 +2673,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1009,
@@ -2583,6 +2694,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4,
@@ -2603,6 +2715,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.90000009536743,
@@ -2623,6 +2736,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 16,
@@ -2643,6 +2757,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4.69999980926514,
@@ -2664,6 +2779,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 8,
@@ -2684,6 +2800,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10,
@@ -2704,6 +2821,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1.29999995231628,
@@ -2725,6 +2843,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6,
@@ -2746,6 +2865,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 241,
@@ -2767,6 +2887,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 240,
@@ -2787,6 +2908,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 19.2999992370605,
@@ -2808,6 +2930,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -2894,6 +3017,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 22,
@@ -2915,6 +3039,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 3.09999990463257,
@@ -2935,6 +3060,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 320,
@@ -2955,6 +3081,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -2.40000009536743,
@@ -2975,6 +3102,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.699999988079071,
@@ -2996,6 +3124,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 12,
@@ -3017,6 +3146,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 999.200012207031,
@@ -3038,6 +3168,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -3123,6 +3254,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-12-30T00:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1024.07434082031,
@@ -3141,6 +3273,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13.3100004196167,
@@ -3159,6 +3292,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.555139541626,
@@ -3177,6 +3311,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 11.6999998092651,
@@ -3195,6 +3330,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-12-30T00:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 306.399993896484,
@@ -3213,6 +3349,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-12-30T00:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -3337,6 +3474,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5,
@@ -3357,6 +3495,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 70,
@@ -3377,6 +3516,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1.29999995231628,
@@ -3397,6 +3537,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.59999990463257,
@@ -3417,6 +3558,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13,
@@ -3437,6 +3579,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 3.09999990463257,
@@ -3457,6 +3600,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 220,
@@ -3477,6 +3621,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7.19999980926514,
@@ -3497,6 +3642,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1005.70001220703,
@@ -3517,6 +3663,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 11.8000001907349,
@@ -3537,6 +3684,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -0.400000005960464,
@@ -3557,6 +3705,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4,
@@ -3577,6 +3726,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -3662,6 +3812,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1007.03741455078,
@@ -3680,6 +3831,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-01-03T18:29:27Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14.6300001144409,
@@ -3698,6 +3850,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 11.3800001144409,
@@ -3716,6 +3869,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 25.1474456787109,
@@ -3734,6 +3888,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-01-03T18:29:27Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 20.2900009155273,
@@ -3752,6 +3907,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -3803,6 +3959,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.2999992370605,
@@ -3824,6 +3981,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -3989,6 +4147,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1,
@@ -4009,6 +4168,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7,
@@ -4029,6 +4189,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7,
@@ -4049,6 +4210,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.09999990463257,
@@ -4069,6 +4231,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1000.20001220703,
@@ -4089,6 +4252,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 15.3999996185303,
@@ -4109,6 +4273,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 240,
@@ -4129,6 +4294,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 3.5,
@@ -4149,6 +4315,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 11.6999998092651,
@@ -4169,6 +4336,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -4220,6 +4388,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.5534210205078,
@@ -4241,6 +4410,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7.44999980926514,
@@ -4262,6 +4432,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 25.2324466705322,
@@ -4283,6 +4454,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 16.1900005340576,
@@ -4303,6 +4475,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T16:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 33.818000793457,
@@ -4324,6 +4497,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.67000007629395,
@@ -4344,6 +4518,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-29T19:19:19Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 25.711051940918,
@@ -4365,6 +4540,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.9096946716309,
@@ -4386,6 +4562,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 23.9673461914062,
@@ -4407,6 +4584,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.088436126709,
@@ -4428,6 +4606,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13.8599996566772,
@@ -4449,6 +4628,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 38.6679992675781,
@@ -4470,6 +4650,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2322.9775390625,
@@ -4490,6 +4671,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T16:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1002.48999023438,
@@ -4510,6 +4692,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T16:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 34.6559982299805,
@@ -4531,6 +4714,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-16T15:35:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 290.853210449219,
@@ -4551,6 +4735,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-07-09T15:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 18.4778995513916,
@@ -4571,6 +4756,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-07-09T15:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.40522074699402,
@@ -4591,6 +4777,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2003-07-09T05:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10.6666669845581,
@@ -4611,6 +4798,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2003-07-09T05:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -4661,6 +4849,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1001.90002441406,
@@ -4681,6 +4870,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10.8000001907349,
@@ -4701,6 +4891,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.800000011920929,
@@ -4721,6 +4912,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.90000009536743,
@@ -4741,6 +4933,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 230,
@@ -4761,6 +4954,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 11.3000001907349,
@@ -4781,6 +4975,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -4829,6 +5024,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T18:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.368049621582,
@@ -4850,6 +5046,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1.50999999046326,
@@ -4870,6 +5067,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-29T19:17:36Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 27.1389999389648,
@@ -4891,6 +5089,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 25.623713,
@@ -4912,6 +5111,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: undefined,
@@ -4933,6 +5133,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2976.54516601562,
@@ -4953,6 +5154,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T18:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.324,
@@ -4974,6 +5176,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 21.8259811401367,
@@ -4995,6 +5198,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.574795,
@@ -5016,6 +5220,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1001.86364746094,
@@ -5036,6 +5241,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T18:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.29699993133545,
@@ -5054,6 +5260,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T18:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.810143172740936,
@@ -5074,6 +5281,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-01-06T17:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 12.126914024353,
@@ -5094,6 +5302,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.5348,
@@ -5114,6 +5323,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14.0900001525879,
@@ -5134,6 +5344,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T18:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 239,
@@ -5152,6 +5363,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-09-29T18:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14.0784,
@@ -5172,6 +5384,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-27T08:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5,
@@ -5192,6 +5405,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-01-06T17:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -5240,6 +5454,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-20T12:46:24Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14,
@@ -5258,6 +5473,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-20T12:46:24Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 20,
@@ -5276,6 +5492,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-20T12:46:24Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -5327,6 +5544,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-08-21T18:26:42Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 16.8999996185303,
@@ -5347,6 +5565,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-23T15:58:17Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.400000005960464,
@@ -5367,6 +5586,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2019-05-23T17:09:45Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -5424,6 +5644,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 12,
@@ -5444,6 +5665,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -4.59999990463257,
@@ -5464,6 +5686,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: undefined,
@@ -5484,6 +5707,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 25,
@@ -5504,6 +5728,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1012.70001220703,
@@ -5525,6 +5750,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10.3000001907349,
@@ -5545,6 +5771,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7.19999980926514,
@@ -5565,6 +5792,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 310,
@@ -5585,6 +5813,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -5635,6 +5864,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.90000009536743,
@@ -5656,6 +5886,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.5,
@@ -5677,6 +5908,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 8,
@@ -5697,6 +5929,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10,
@@ -5717,6 +5950,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -5768,6 +6002,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-20T12:08:04Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 8.11804485321045,
@@ -5788,6 +6023,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-20T12:08:04Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 31.9048309326172,
@@ -5808,6 +6044,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-20T12:08:04Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 15.0569677352905,
@@ -5828,6 +6065,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-20T12:06:38Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -5878,6 +6116,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -3.70000004768372,
@@ -5898,6 +6137,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1004.29998779297,
@@ -5919,6 +6159,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.400000005960464,
@@ -5939,6 +6180,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 11.8000001907349,
@@ -5959,6 +6201,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10.8000001907349,
@@ -5979,6 +6222,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 9.30000019073486,
@@ -5999,6 +6243,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 10.1000003814697,
@@ -6019,6 +6264,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 290,
@@ -6039,6 +6285,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -6087,6 +6334,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-10-01T15:30:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 38.5866012573242,
@@ -6108,6 +6356,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 9.02929973602295,
@@ -6129,6 +6378,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 31.8993816375732,
@@ -6150,6 +6400,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.9866161346436,
@@ -6171,6 +6422,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1003.59619140625,
@@ -6191,6 +6443,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-10-01T15:30:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.448358088731766,
@@ -6211,6 +6464,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-03-28T21:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 34.5878982543945,
@@ -6232,6 +6486,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 23.7952518463135,
@@ -6253,6 +6508,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 32.282527923584,
@@ -6274,6 +6530,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 6.58599996566772,
@@ -6292,6 +6549,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-10-01T15:30:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13.9881000518799,
@@ -6313,6 +6571,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2,
@@ -6333,6 +6592,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2002-03-28T21:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2993.36499023438,
@@ -6351,6 +6611,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-10-01T15:30:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 292.899993896484,
@@ -6369,6 +6630,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-10-01T15:30:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4.82600021362305,
@@ -6387,6 +6649,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2018-10-01T15:30:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 39.8890991210938,
@@ -6408,6 +6671,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2001-07-09T21:15:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -6459,6 +6723,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.09999990463257,
@@ -6479,6 +6744,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1,
@@ -6500,6 +6766,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.400000005960464,
@@ -6520,6 +6787,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 260,
@@ -6540,6 +6808,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 999.5,
@@ -6561,6 +6830,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 12.3999996185303,
@@ -6582,6 +6852,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 3.09999990463257,
@@ -6602,6 +6873,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.09999990463257,
@@ -6622,6 +6894,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -6673,6 +6946,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.5,
@@ -6694,6 +6968,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 3,
@@ -6715,6 +6990,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 242,
@@ -6735,6 +7011,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 17.7999992370605,
@@ -6756,6 +7033,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -6814,6 +7092,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 330,
@@ -6834,6 +7113,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -4.30000019073486,
@@ -6854,6 +7134,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.300000011920929,
@@ -6874,6 +7155,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5,
@@ -6894,6 +7176,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1003.90002441406,
@@ -6914,6 +7197,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: -1.29999995231628,
@@ -6934,6 +7218,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14.1999998092651,
@@ -6954,6 +7239,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.5,
@@ -6974,6 +7260,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 113,
@@ -6994,6 +7281,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.899999976158142,
@@ -7014,6 +7302,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7.69999980926514,
@@ -7034,6 +7323,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 5,
@@ -7054,6 +7344,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14,
@@ -7074,6 +7365,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7124,6 +7416,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0,
@@ -7144,6 +7437,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 9.30000019073486,
@@ -7164,6 +7458,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4.69999980926514,
@@ -7184,6 +7479,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1008.29998779297,
@@ -7205,6 +7501,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 240,
@@ -7225,6 +7522,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 8.10000038146973,
@@ -7245,6 +7543,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7296,6 +7595,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 4.59999990463257,
@@ -7316,6 +7616,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 14.1999998092651,
@@ -7337,6 +7638,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1004.70001220703,
@@ -7358,6 +7660,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.7999992370605,
@@ -7379,6 +7682,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:00:00Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7429,6 +7733,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T16:42:58Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 13.3000001907349,
@@ -7450,6 +7755,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T16:43:01Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1001,
@@ -7471,6 +7777,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T16:43:47Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 8.80000019073486,
@@ -7491,6 +7798,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T16:42:57Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 21.7999992370605,
@@ -7512,6 +7820,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T16:42:55Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [],
@@ -7552,6 +7861,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2020-08-25T21:17:25Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7603,6 +7913,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T13:38:08Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1005.09997558594,
@@ -7624,6 +7935,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T13:38:09Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 24.6000003814697,
@@ -7645,6 +7957,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T13:38:07Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7696,6 +8009,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T19:50:18Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.300000011920929,
@@ -7717,6 +8031,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T19:50:15Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 18.5,
@@ -7738,6 +8053,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T19:50:12Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 26.5,
@@ -7759,6 +8075,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T19:50:10Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7810,6 +8127,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:08:43Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 26.5,
@@ -7831,6 +8149,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:08:03Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7882,6 +8201,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:19:57Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1006.40002441406,
@@ -7903,6 +8223,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:22:43Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 0.899999976158142,
@@ -7924,6 +8245,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:22:35Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 15.1999998092651,
@@ -7945,6 +8267,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "1970-02-26T20:22:35Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -7996,6 +8319,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:07:06Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 2.20000004768372,
@@ -8017,6 +8341,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:07:06Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1009.40002441406,
@@ -8038,6 +8363,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:07:06Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 19.7000007629395,
@@ -8059,6 +8385,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:07:06Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 19,
@@ -8080,6 +8407,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:07:13Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 290,
@@ -8100,6 +8428,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:07:15Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 9,
@@ -8120,6 +8449,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:07:18Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -8171,6 +8501,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:00:51Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 17.7999992370605,
@@ -8192,6 +8523,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:00:52Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 280,
@@ -8212,6 +8544,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:00:54Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 8,
@@ -8232,6 +8565,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T18:56:23Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [
@@ -8282,6 +8616,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:35:53Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 7,
@@ -8302,6 +8637,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:35:53Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 1008.5,
@@ -8323,6 +8659,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:35:53Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 21.3999996185303,
@@ -8344,6 +8681,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:35:56Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
         {
           value: 18.7000007629395,
@@ -8365,6 +8703,7 @@ export const platforms: PlatformFeature[] = [
           start_time: "2016-09-16T19:35:58Z",
           flood_levels: [],
           datum_offsets: {},
+          highlighted: "No",
         },
       ],
       attribution: [


### PR DESCRIPTION
Adds the ability to show highlighted timeseries, and standardizes which timeseries are selected between the sidebar and the current conditions view.

Highlighted timeseries can either go before or after the standard set (which has wind first). They aren't identified as something special, they just get added to the list in addition to the standard set.

If a one of the standard set of conditions is highlighted, then it's removed from the standard set (other than wind).

Closes #2876