### PR TITLE
persist unit selection on page refresh and new platform/sensor selection

### DIFF
--- a/app/store.ts
+++ b/app/store.ts
@@ -2,10 +2,39 @@ import { configureStore } from "@reduxjs/toolkit"
 
 import { unitReducer as unit } from "Features/Units"
 
+const preloadedState = loadFromLocalStorage()
+
 export const store = configureStore({
   reducer: {
     unit,
   },
+  preloadedState: {
+    unit: preloadedState,
+  },
+})
+
+store.subscribe(() => {
+  saveToLocalStorage(store.getState().unit)
 })
 
 export type RootState = ReturnType<typeof store.getState>
+
+function saveToLocalStorage(state) {
+  try {
+    const serializedState = JSON.stringify(state)
+    sessionStorage.setItem("unit", serializedState)
+  } catch (e) {
+    console.error("Could not save state", e)
+  }
+}
+
+function loadFromLocalStorage() {
+  try {
+    const serializedState = sessionStorage.getItem("unit")
+    if (serializedState === null) return undefined
+    return JSON.parse(serializedState)
+  } catch (e) {
+    console.error("Could not load state", e)
+    return undefined
+  }
+}


### PR DESCRIPTION
This adds "unit" to `sessionStorage` along side `redux` so unit persists on refresh and platform selection when on the same tab. If another tab/window/session is opened, the unit selection will default back to initial state (English units).

Meant to make this a draft PR, whoops. I'm not sure we want units in session storage for the entire app or just for the water level portion. Seems like this universal change won't be super intrusive for how I understand most users use the buoy dashboard, but happy to receive feedback on this.

closes #2858