### PR TITLE
Adelle/fix map color render

### DIFF
--- a/app/(waterLevel)/water-level/sensor/[sensorId]/[startTime]/[endTime]/[datum]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/[startTime]/[endTime]/[datum]/page.tsx
@@ -41,7 +41,7 @@ export default function SensorIdPage({ params }) {
             <ErddapWaterLevelMapBase
               platforms={waterLevelPlatforms}
               platformId={id}
-              height={"30vh"}
+              height={"40vh"}
               mapView={{ center: fromLonLat([-69.7, 43]), zoom: 6 }}
             />
           )}

--- a/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
+++ b/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
@@ -105,14 +105,16 @@ export const WLPlatformLayer = ({ platform, selected, old = false }: PlatformLay
 
   if (display) {
     return (
-      <Layer
-        platform={platform}
-        url={url}
-        router={router}
-        radius={radius}
-        color={display}
-        floodThreshold={floodThreshold}
-      />
+      <div style={{ zIndex: 10 }}>
+        <Layer
+          platform={platform}
+          url={url}
+          router={router}
+          radius={radius}
+          color={display}
+          floodThreshold={floodThreshold}
+        />
+      </div>
     )
   } else {
     return null
@@ -121,7 +123,7 @@ export const WLPlatformLayer = ({ platform, selected, old = false }: PlatformLay
 
 const Layer = ({ platform, url, router, radius, color, floodThreshold }) => {
   return (
-    <RLayerVector>
+    <RLayerVector zIndex={10}>
       <RStyle.RStyle>
         <RStyle.RRegularShape radius={radius} points={4} angle={2.35}>
           <RStyle.RFill color={color} />
@@ -141,8 +143,8 @@ const Layer = ({ platform, url, router, radius, color, floodThreshold }) => {
           router.push(url)
         }, [router, url])}
       >
-        <RPopup trigger={"hover"}>
-          <Button color="dark" size="sm" href={url}>
+        <RPopup trigger={"hover"} autoPosition={true}>
+          <Button color="dark" size="sm" href={url} className="map-popup">
             {platformName(platform)} <br></br>Flood level: {floodThreshold ? floodThreshold : "None"}
           </Button>
         </RPopup>

--- a/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
+++ b/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
@@ -67,7 +67,7 @@ export const WLPlatformLayer = ({ platform, selected, old = false }: PlatformLay
   const path = usePathname()
   const waterLevelSensorPage = path.includes("water-level")
   const params = useParams()
-  const [floodThreshold, setFloodThreshold] = useState<string>("None")
+  const [floodThreshold, setFloodThreshold] = useState<string>("")
   const [display, setDisplay] = useState()
 
   let radius: number

--- a/src/Features/ERDDAP/waterLevel/map.tsx
+++ b/src/Features/ERDDAP/waterLevel/map.tsx
@@ -61,6 +61,14 @@ export const ErddapWaterLevelMapBase: React.FC<Props> = ({ platforms, platformId
   return (
     <div style={{ position: "relative" }}>
       <RMap ref={mapRef} className="map" initial={initial} view={[view || initial, setView]} height={height}>
+        <div className="legend-container">
+          <LegendItem color={"#80ff00"} text={"No Flooding"} />
+          <LegendItem color={"#ffff00"} text={"Action"} />
+          <LegendItem color={"#ff9000"} text={"Minor"} />
+          <LegendItem color={"#ff2000"} text={"Moderate"} />
+          <LegendItem color={"#aa00ff"} text={"Major"} />
+          <LegendItem color={"grey"} text={"No Flood Threshold Data"} />
+        </div>
         <EsriOceanBasemapLayer />
         <EsriOceanReferenceLayer />
 
@@ -73,14 +81,6 @@ export const ErddapWaterLevelMapBase: React.FC<Props> = ({ platforms, platformId
         {!!selectedPlatforms.length && (
           <WLPlatformLayer key={selectedPlatforms[0].id} platform={selectedPlatforms[0]} selected={true} old={false} />
         )}
-        <div className="legend-container">
-          <LegendItem color={"#80ff00"} text={"No Flooding"} />
-          <LegendItem color={"#ffff00"} text={"Action"} />
-          <LegendItem color={"#ff9000"} text={"Minor"} />
-          <LegendItem color={"#ff2000"} text={"Moderate"} />
-          <LegendItem color={"#aa00ff"} text={"Major"} />
-          <LegendItem color={"grey"} text={"No Flood Threshold Data"} />
-        </div>
       </RMap>
     </div>
   )

--- a/src/index.scss
+++ b/src/index.scss
@@ -77,6 +77,12 @@ nav.navbar {
   color: $coastal-meadow;
 }
 
+.map .ol-zoom {
+  top: 10px;
+  left: auto;
+  right: 10px;
+}
+
 .legend-item {
   display: flex;
   align-items: center;
@@ -91,12 +97,16 @@ nav.navbar {
 
 .legend-container {
   position: absolute;
-  right: 0;
-  bottom: 40px;
-  z-index: 2;
+  left: 10px;
+  top: 10px;
+  z-index: 1;
   background-color: #ffffff;
   padding: 5px;
   margin-right: 10px;
+}
+
+.map-popup {
+  z-index: 10;
 }
 
 .chart-display {


### PR DESCRIPTION
This PR includes some improvements to the map:
- Fixes initial state so the map renders the points with their correct flood thresholds
- Moves the legend and controls so there is no overlap with popups
- Increases the height of the map so all popups can be seen in initial viewpoint (no need to scroll)

<img width="1725" alt="Screenshot 2024-05-10 at 12 02 44 PM" src="https://github.com/gulfofmaine/Neracoos-1-Buoy-App/assets/108096652/79e42440-caa3-4a7e-94a3-019770417ffa">

Closes #2859 