### PR TITLE
make y-axis dynamic for min and max

### DIFF
--- a/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
@@ -34,6 +34,9 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
   const [floodThresholds, setFloodThresholds] = useState<any>()
   const [datumOffset, setDatumOffset] = useState<number | undefined>()
   const [title, setTitle] = useState<string>()
+  const [yMax, setYMax] = useState<number>()
+  const [yMin, setYMin] = useState<number>()
+
   const params = useParams()
   const dataConverter = converter(standardName)
   const sensorId = decodeURIComponent(params.sensorId as string)
@@ -75,7 +78,11 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
       const offsetName = Object.keys(timeSeries.datum_offsets).find((d) => d.includes(datum.toLowerCase()))
       offsetName && setDatumOffset(timeSeries.datum_offsets[offsetName])
     }
-  }, [params.datum, unitSystem])
+    const allReadings = dataset.timeSeries.map((t) => t.reading)
+
+    setYMax(dataConverter.convertToNumber(Math.max(...allReadings), unitSystem))
+    setYMin(dataConverter.convertToNumber(Math.min(...allReadings), unitSystem))
+  }, [params.datum, unitSystem, dataset])
 
   useEffect(() => {
     if (timeSeries) {
@@ -97,8 +104,8 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
         predictedTidesTimeSeries={predictedTidesDataset?.timeSeries}
         predictedTidesName={predictedTidesDataset?.name}
         name={title}
-        softMin={0}
-        softMax={{ English: 20, Metric: 10 }}
+        softMin={yMin as number}
+        softMax={yMax as number}
         unitSystem={unitSystem}
         data_type={standardName}
         datumOffset={datumOffset || 0}

--- a/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
@@ -47,6 +47,12 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
     }
   }
 
+  const getMaxThreshold = () => {
+    return Object.keys(floodThresholds).reduce((max, f) => {
+      return floodThresholds[f].maxValue > max ? floodThresholds[f].maxValue : max
+    }, 0)
+  }
+
   useEffect(() => {
     if (timeSeries.flood_levels.length) {
       const floodLevelsMap = timeSeries.flood_levels.reduce((acc, level, index) => {
@@ -78,11 +84,17 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
       const offsetName = Object.keys(timeSeries.datum_offsets).find((d) => d.includes(datum.toLowerCase()))
       offsetName && setDatumOffset(timeSeries.datum_offsets[offsetName])
     }
-    const allReadings = dataset.timeSeries.map((t) => t.reading)
+  }, [params.datum, timeSeries])
 
-    setYMax(dataConverter.convertToNumber(Math.max(...allReadings), unitSystem))
+  useEffect(() => {
+    const allReadings = dataset.timeSeries.map((t) => t.reading)
+    setYMax(
+      floodThresholds
+        ? dataConverter.convertToNumber(getMaxThreshold(), unitSystem)
+        : dataConverter.convertToNumber(Math.max(...allReadings), unitSystem),
+    )
     setYMin(dataConverter.convertToNumber(Math.min(...allReadings), unitSystem))
-  }, [params.datum, unitSystem, dataset])
+  }, [floodThresholds, dataset, unitSystem])
 
   useEffect(() => {
     if (timeSeries) {

--- a/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
@@ -38,9 +38,9 @@ interface Props {
   /** Name of data */
   name: string | undefined
   /** Soft minimum for Y axis */
-  softMin: number | undefined
+  softMin: number
   /** Soft maximum for Y axis */
-  softMax: any
+  softMax: number
   /** Unit system to display in */
   unitSystem: UnitSystem
   /** Data type to display */
@@ -123,7 +123,7 @@ export function LargeTimeSeriesWaterLevelChart({
         </XAxis>
         <YAxis
           softMin={softMin}
-          softMax={floodThresholds ? floodThresholds?.Major?.minValue + 3 : softMax[unitSystem]}
+          softMax={floodThresholds ? floodThresholds?.Major?.minValue + 3 : softMax}
           endOnTick={false}
         >
           {floodThresholds && (

--- a/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
@@ -123,7 +123,11 @@ export function LargeTimeSeriesWaterLevelChart({
         </XAxis>
         <YAxis
           softMin={softMin}
-          softMax={floodThresholds ? floodThresholds?.Major?.minValue + 3 : softMax}
+          softMax={
+            floodThresholds
+              ? floodThresholds?.Major?.minValue + dataConverter.convertToNumber(0.5, unitSystem)
+              : softMax
+          }
           endOnTick={false}
         >
           {floodThresholds && (


### PR DESCRIPTION
This finally fixes the y axis for tide gauge data

- On gauges that don't have flood thresholds, it calculates the max value from current timeseries and makes it a soft max
- On gauges that do have flood thresholds, it adjusts the max to be .5 units (metric or english) above that threshold (so we don't have enormous max plotbands--see before pic below)

Before (no thresholds):
![Screenshot 2024-07-17 at 4 14 59 PM](https://github.com/user-attachments/assets/c3d954a3-28cf-4e87-94df-b4f1f7b3aa45)

After (no thresholds):
![Screenshot 2024-07-17 at 4 15 31 PM](https://github.com/user-attachments/assets/db4c5686-11b8-4a72-bd57-9699c61bb7ff)

Before (thresholds):
![Screenshot 2024-07-17 at 4 15 58 PM](https://github.com/user-attachments/assets/6ed1ef78-5db8-4be8-8bc4-4a9e6cc3fe25)

After (thresholds):
![Screenshot 2024-07-17 at 4 16 21 PM](https://github.com/user-attachments/assets/0b5f905a-9316-4f10-9890-b1e34ff398b7)


