### PR TITLE
Adelle/current wl clean up

### DIFF
--- a/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
+++ b/app/(platformMap)/@sidebar/platform/[platformId]/page.tsx
@@ -1,4 +1,5 @@
 import { PlatformInfo } from "components/PlatformInfo/platformInfo"
+import React from "react"
 import { useDecodedUrl } from "util/hooks"
 
 export default async function PlatformSidebar({ params }: { params: { platformId: string } }) {

--- a/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { usePlatforms } from "Features/ERDDAP/hooks"
+import { usePlatform, usePlatforms } from "Features/ERDDAP/hooks"
 import { PlatformFeature } from "Features/ERDDAP/types"
 import { ErddapWaterLevelMapBase } from "Features/ERDDAP/waterLevel/map"
 import { WaterLevelObservationContent } from "Features/ERDDAP/waterLevel/observationContent"
@@ -19,8 +19,9 @@ const useBreakpoint = createBreakpoint({ S: 576, M: 768, L: 992 })
 export default function SensorIdPage({ params }) {
   const breakpoint = useBreakpoint()
   const { data } = usePlatforms()
-  const [waterLevelPlatforms, setWaterLevelPlatforms] = useState<PlatformFeature[] | undefined>()
   const id = useDecodedUrl(params.sensorId)
+  const [waterLevelPlatforms, setWaterLevelPlatforms] = useState<PlatformFeature[] | undefined>()
+  const [platform, setPlatform] = useState<PlatformFeature>()
 
   useEffect(() => {
     if (data) {
@@ -30,6 +31,10 @@ export default function SensorIdPage({ params }) {
       })
       const platforms = filterForSensors(data)
       setWaterLevelPlatforms(platforms)
+      if (id) {
+        const platform = usePlatform(platforms, id)
+        setPlatform(platform)
+      }
     }
   }, [data])
 
@@ -37,7 +42,9 @@ export default function SensorIdPage({ params }) {
     <div>
       <Row>
         <Col sm={{ size: "6" }} md={{ size: "4" }}>
-          <WaterLevelSensorInfo id={id} sensors={waterLevelPlatforms} />
+          {waterLevelPlatforms && platform && (
+            <WaterLevelSensorInfo platform={platform} sensors={waterLevelPlatforms} />
+          )}
           {breakpoint !== "S" && waterLevelPlatforms && (
             <ErddapWaterLevelMapBase
               platforms={waterLevelPlatforms}

--- a/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { usePlatform, usePlatforms } from "Features/ERDDAP/hooks"
+import { usePlatforms } from "Features/ERDDAP/hooks"
 import { PlatformFeature } from "Features/ERDDAP/types"
 import { ErddapWaterLevelMapBase } from "Features/ERDDAP/waterLevel/map"
 import { WaterLevelObservationContent } from "Features/ERDDAP/waterLevel/observationContent"
@@ -12,15 +12,15 @@ import { Col, Row } from "reactstrap"
 import { useDecodedUrl } from "util/hooks"
 import { createBreakpoint } from "react-use"
 import { WaterLevelSensorInfo } from "components/PlatformInfo/WaterLevelSensorInfo"
+import { useSearchParams } from "next/navigation"
 
 const useBreakpoint = createBreakpoint({ S: 576, M: 768, L: 992 })
 
 export default function SensorIdPage({ params }) {
   const breakpoint = useBreakpoint()
   const { data } = usePlatforms()
-  const id = useDecodedUrl(params.sensorId)
   const [waterLevelPlatforms, setWaterLevelPlatforms] = useState<PlatformFeature[] | undefined>()
-  const [platform, setPlatform] = useState<PlatformFeature>()
+  const id = useDecodedUrl(params.sensorId)
 
   useEffect(() => {
     if (data) {
@@ -30,10 +30,6 @@ export default function SensorIdPage({ params }) {
       })
       const platforms = filterForSensors(data)
       setWaterLevelPlatforms(platforms)
-      if (id) {
-        const platform = usePlatform(platforms, id)
-        setPlatform(platform)
-      }
     }
   }, [data])
 
@@ -41,9 +37,7 @@ export default function SensorIdPage({ params }) {
     <div>
       <Row>
         <Col sm={{ size: "6" }} md={{ size: "4" }}>
-          {waterLevelPlatforms && platform && (
-            <WaterLevelSensorInfo platform={platform} sensors={waterLevelPlatforms} />
-          )}
+          {waterLevelPlatforms && <WaterLevelSensorInfo id={id} sensors={waterLevelPlatforms} />}
           {breakpoint !== "S" && waterLevelPlatforms && (
             <ErddapWaterLevelMapBase
               platforms={waterLevelPlatforms}

--- a/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
@@ -12,7 +12,6 @@ import { Col, Row } from "reactstrap"
 import { useDecodedUrl } from "util/hooks"
 import { createBreakpoint } from "react-use"
 import { WaterLevelSensorInfo } from "components/PlatformInfo/WaterLevelSensorInfo"
-import { useSearchParams } from "next/navigation"
 
 const useBreakpoint = createBreakpoint({ S: 576, M: 768, L: 992 })
 

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
@@ -37,7 +37,7 @@ export const ErddapCurrentPlatformConditions: React.FunctionComponent<Props> = (
   )
 
   return (
-    <UseDatasets timeSeries={allCurrentConditionsTimeseries} startTime={halfDayAgo}>
+    <UseDatasets timeSeries={allCurrentConditionsTimeseries} startTime={halfDayAgo} platformId={platform.id}>
       {({ datasets }) => {
         const times = datasets
           .map((ds) => ds.timeSeries)

--- a/src/Features/ERDDAP/Platform/Observations/WaterLevel/WLErddapObservationTable.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WaterLevel/WLErddapObservationTable.tsx
@@ -68,13 +68,7 @@ export const WLErddapObservationTable: React.FC<Props> = ({
         <ListGroupItem style={itemStyle}>There is no recent data from {platformName(platform)}</ListGroupItem>
       )}
       {waterLevelTimeseries && (
-        <TableItem
-          key="WL-ts"
-          timeSeries={waterLevelTimeseries}
-          platform={platform}
-          unitSystem={unitSystem}
-          startTime={laterThan}
-        />
+        <TableItem key="WL-ts" timeSeries={waterLevelTimeseries} platform={platform} unitSystem={unitSystem} />
       )}
 
       {unitSelector ? (

--- a/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
@@ -40,7 +40,7 @@ export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ pl
   }
 
   return (
-    <UseDatasets timeSeries={timeSeries} startTime={startDate}>
+    <UseDatasets timeSeries={timeSeries} startTime={startDate} platformId={platform.id}>
       {({ datasets }) => (
         <ErddapWindObservedConditionDisplay {...{ platform, unitSystem, timeSeries, datasets, startDate }} />
       )}

--- a/src/Features/ERDDAP/hooks/TableDAPComponents.tsx
+++ b/src/Features/ERDDAP/hooks/TableDAPComponents.tsx
@@ -23,7 +23,6 @@ interface UseDatasetsProps {
 
 export interface UseDatasetsRenderProps {
   datasets: DataTimeSeries[]
-  platforms: PlatformTimeSeries
 }
 
 interface UseQueryGroupResult {
@@ -76,7 +75,6 @@ export const UseDatasets: React.FunctionComponent<UseDatasetsProps> = ({
       }
     }
   }
-  let updatedPlatforms
 
   if (loadedDatasets && platformId) {
     const platforms: any = queryClient.getQueryData(["buoybarn-platforms"])
@@ -102,12 +100,15 @@ export const UseDatasets: React.FunctionComponent<UseDatasetsProps> = ({
           readings: updatedReadings,
         },
       }
-
-      updatedPlatforms = {
+      const updatedPlatforms = {
         ...platforms,
         features: platforms.features.map((f) => (f.id === platformId ? updatedPlatform : f)),
       }
-      // queryClient.setQueryData(['buoybarn-platforms'], platforms);
+      const updatedValues = updatedReadings.map((r) => r.value).toString()
+      const originalValues = platform.properties.readings.map((r) => r.value).toString()
+      if (originalValues !== updatedValues) {
+        queryClient.setQueryData(["buoybarn-platforms"], updatedPlatforms)
+      }
     }
   }
 
@@ -117,7 +118,7 @@ export const UseDatasets: React.FunctionComponent<UseDatasetsProps> = ({
 
       {errorGroups.length > 0 ? <Alert color="warning">Error loading datasets</Alert> : null}
 
-      {loadedDatasets.length > 0 ? children({ datasets: loadedDatasets, platforms: updatedPlatforms }) : null}
+      {loadedDatasets.length > 0 ? children({ datasets: loadedDatasets }) : null}
     </React.Fragment>
   )
 }

--- a/src/Features/ERDDAP/hooks/TableDAPComponents.tsx
+++ b/src/Features/ERDDAP/hooks/TableDAPComponents.tsx
@@ -76,6 +76,7 @@ export const UseDatasets: React.FunctionComponent<UseDatasetsProps> = ({
     }
   }
 
+  //Combine latest values from useDataset and combines them into usePlatform data. If the recent value from useDataset is different than the value from usePlatform, it will pull into update usePlatform.
   if (loadedDatasets && platformId) {
     const platforms: any = queryClient.getQueryData(["buoybarn-platforms"])
     if (platforms) {
@@ -92,7 +93,6 @@ export const UseDatasets: React.FunctionComponent<UseDatasetsProps> = ({
         const update = latestReading.find((r) => r.name === reading.variable)
         return update ? { ...reading, value: update.latestValue, time: update.time } : { ...reading }
       })
-
       const updatedPlatform = {
         ...platform,
         properties: {
@@ -106,6 +106,7 @@ export const UseDatasets: React.FunctionComponent<UseDatasetsProps> = ({
       }
       const updatedValues = updatedReadings.map((r) => r.value).toString()
       const originalValues = platform.properties.readings.map((r) => r.value).toString()
+      // If original values are different than the new values (i.e. a new reading was taken),then set usePlatform data to the updated values.
       if (originalValues !== updatedValues) {
         queryClient.setQueryData(["buoybarn-platforms"], updatedPlatforms)
       }

--- a/src/Features/ERDDAP/waterLevel/DatumSelector.tsx
+++ b/src/Features/ERDDAP/waterLevel/DatumSelector.tsx
@@ -10,6 +10,8 @@ export const DatumSelector = ({ datumOffsets }: { datumOffsets: DatumOffsets }) 
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const [datumSelected, setDatumSelected] = useState(searchParams.get("datum"))
+  const endTime = searchParams.get("end")
+  const startTime = searchParams.get("start")
 
   const createQueryString = useCallback(
     (name: string, value: string) => {
@@ -41,7 +43,7 @@ export const DatumSelector = ({ datumOffsets }: { datumOffsets: DatumOffsets }) 
       })
       setDatumOptions(options.length ? options : null)
     }
-  }, [datumOffsets, datumSelected])
+  }, [datumOffsets, datumSelected, startTime, endTime])
 
   useEffect(() => {
     setDatumSelected(searchParams.get("datum"))

--- a/src/Features/ERDDAP/waterLevel/observationBase.tsx
+++ b/src/Features/ERDDAP/waterLevel/observationBase.tsx
@@ -65,7 +65,7 @@ export const WaterLevelObservationBase = ({ platform }) => {
             endTime={manuallySetFullEODIso(endTime)}
             platformId={platform.id}
           >
-            {({ datasets, platforms }) => {
+            {({ datasets }) => {
               const times = datasets
                 .map((ds) => ds.timeSeries)
                 .flat()

--- a/src/Features/ERDDAP/waterLevel/observationBase.tsx
+++ b/src/Features/ERDDAP/waterLevel/observationBase.tsx
@@ -3,20 +3,12 @@ import { useUnitSystem } from "Features/Units"
 import { useEffect, useState } from "react"
 import { Alert } from "reactstrap"
 import { filterTimeSeries } from "../Platform/Observations/CurrentConditions"
-import { UseDatasets, useDataset } from "../hooks"
+import { UseDatasets } from "../hooks"
 import { DatumOffsetOptions, PlatformTimeSeries } from "../types"
 import { conditions } from "../utils/conditions"
 import { filterWaterLevelTimeSeries } from "../Platform/Observations/CurrentConditions/waterLevel"
-import {
-  aDayAgoRounded,
-  daysInFuture,
-  fullBeginningDateIso,
-  getIsoForPicker,
-  getToday,
-  manuallySetFullEODIso,
-  threeDaysAgoRounded,
-} from "Shared/time"
-import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation"
+import { aDayAgoRounded, fullBeginningDateIso, getIsoForPicker, getToday, manuallySetFullEODIso } from "Shared/time"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import queryString from "query-string"
 import { buildSearchParamsQuery } from "Shared/urlParams"
 
@@ -71,8 +63,9 @@ export const WaterLevelObservationBase = ({ platform }) => {
             timeSeries={predictedTides ? [waterLevel, predictedTides] : [waterLevel]}
             startTime={fullBeginningDateIso(startTime)}
             endTime={manuallySetFullEODIso(endTime)}
+            platformId={platform.id}
           >
-            {({ datasets }) => {
+            {({ datasets, platforms }) => {
               const times = datasets
                 .map((ds) => ds.timeSeries)
                 .flat()

--- a/src/Features/ERDDAP/waterLevel/observationContent.tsx
+++ b/src/Features/ERDDAP/waterLevel/observationContent.tsx
@@ -1,11 +1,8 @@
-import { useSearchParams } from "next/navigation"
-import { useEffect, useState } from "react"
 import { usePlatform } from "../hooks"
 import { WaterLevelObservationBase } from "./observationBase"
 
 export const WaterLevelObservationContent = ({ sensorId, platforms, allPlatforms }) => {
   const sensor = usePlatform(allPlatforms, sensorId)
-  const searchParams = useSearchParams()
 
   return <div>{sensor ? <WaterLevelObservationBase platform={sensor} /> : null}</div>
 }

--- a/src/components/PlatformInfo/WaterLevelSensorInfo.tsx
+++ b/src/components/PlatformInfo/WaterLevelSensorInfo.tsx
@@ -3,38 +3,33 @@ import React from "react"
 
 import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
 import { ErddapPlatformInfoPanel } from "Features/ERDDAP/Platform/Info"
-import { ErddapObservationTable } from "Features/ERDDAP/Platform/Observations/Table/table"
-import { UsePlatform } from "Features/ERDDAP/hooks/BuoyBarnComponents"
 
 import { UnitSelector, useUnitSystem } from "Features/Units"
 import { aDayAgoRounded } from "Shared/time"
 
 import { PlatformMatchParams } from "./types"
 import { WaterLevelSensorSelector } from "Features/ERDDAP/waterLevel/sensorSelector"
+import { WLErddapObservationTable } from "Features/ERDDAP/Platform/Observations/WaterLevel/WLErddapObservationTable"
 
 /**
  * Display our platform info panel for the select platform.
  */
-export const WaterLevelSensorInfo: React.FC<PlatformMatchParams> = ({ id, sensors }: PlatformMatchParams) => {
+export const WaterLevelSensorInfo: React.FC<PlatformMatchParams> = ({ platform, sensors }: PlatformMatchParams) => {
   const unitSystem = useUnitSystem()
   const aDayAgo = aDayAgoRounded()
 
   return (
-    <UsePlatform platformId={id}>
-      {({ platform }) => (
-        <React.Fragment>
-          <PlatformAlerts platform={platform} />
-          <ErddapPlatformInfoPanel platform={platform} />
-          <ErddapObservationTable
-            platform={platform}
-            unitSelector={<UnitSelector />}
-            unitSystem={unitSystem}
-            laterThan={aDayAgo}
-          >
-            <WaterLevelSensorSelector sensors={sensors} />
-          </ErddapObservationTable>
-        </React.Fragment>
-      )}
-    </UsePlatform>
+    <React.Fragment>
+      <PlatformAlerts platform={platform} />
+      <ErddapPlatformInfoPanel platform={platform} />
+      <WLErddapObservationTable
+        platform={platform}
+        unitSelector={<UnitSelector />}
+        unitSystem={unitSystem}
+        laterThan={aDayAgo}
+      >
+        <WaterLevelSensorSelector sensors={sensors} />
+      </WLErddapObservationTable>
+    </React.Fragment>
   )
 }

--- a/src/components/PlatformInfo/WaterLevelSensorInfo.tsx
+++ b/src/components/PlatformInfo/WaterLevelSensorInfo.tsx
@@ -25,14 +25,14 @@ export const WaterLevelSensorInfo: React.FC<PlatformMatchParams> = ({ id, sensor
         <React.Fragment>
           <PlatformAlerts platform={platform} />
           <ErddapPlatformInfoPanel platform={platform} />
-          <ErddapObservationTable
+          <WLErddapObservationTable
             platform={platform}
             unitSelector={<UnitSelector />}
             unitSystem={unitSystem}
             laterThan={aDayAgo}
           >
             <WaterLevelSensorSelector sensors={sensors} />
-          </ErddapObservationTable>
+          </WLErddapObservationTable>
         </React.Fragment>
       )}
     </UsePlatform>

--- a/src/components/PlatformInfo/WaterLevelSensorInfo.tsx
+++ b/src/components/PlatformInfo/WaterLevelSensorInfo.tsx
@@ -10,26 +10,31 @@ import { aDayAgoRounded } from "Shared/time"
 import { PlatformMatchParams } from "./types"
 import { WaterLevelSensorSelector } from "Features/ERDDAP/waterLevel/sensorSelector"
 import { WLErddapObservationTable } from "Features/ERDDAP/Platform/Observations/WaterLevel/WLErddapObservationTable"
+import { UsePlatform, ErddapObservationTable } from "Features/ERDDAP"
 
 /**
  * Display our platform info panel for the select platform.
  */
-export const WaterLevelSensorInfo: React.FC<PlatformMatchParams> = ({ platform, sensors }: PlatformMatchParams) => {
+export const WaterLevelSensorInfo: React.FC<PlatformMatchParams> = ({ id, sensors }: PlatformMatchParams) => {
   const unitSystem = useUnitSystem()
   const aDayAgo = aDayAgoRounded()
 
   return (
-    <React.Fragment>
-      <PlatformAlerts platform={platform} />
-      <ErddapPlatformInfoPanel platform={platform} />
-      <WLErddapObservationTable
-        platform={platform}
-        unitSelector={<UnitSelector />}
-        unitSystem={unitSystem}
-        laterThan={aDayAgo}
-      >
-        <WaterLevelSensorSelector sensors={sensors} />
-      </WLErddapObservationTable>
-    </React.Fragment>
+    <UsePlatform platformId={id}>
+      {({ platform }) => (
+        <React.Fragment>
+          <PlatformAlerts platform={platform} />
+          <ErddapPlatformInfoPanel platform={platform} />
+          <ErddapObservationTable
+            platform={platform}
+            unitSelector={<UnitSelector />}
+            unitSystem={unitSystem}
+            laterThan={aDayAgo}
+          >
+            <WaterLevelSensorSelector sensors={sensors} />
+          </ErddapObservationTable>
+        </React.Fragment>
+      )}
+    </UsePlatform>
   )
 }

--- a/src/components/PlatformInfo/types.tsx
+++ b/src/components/PlatformInfo/types.tsx
@@ -8,7 +8,7 @@ export interface PlatformMatchParams {
   /**
    * Platform ID from URL parameter
    */
-  platform: PlatformFeature
+  id: string
   sensors?: PlatformFeature[] | undefined
 }
 

--- a/src/components/PlatformInfo/types.tsx
+++ b/src/components/PlatformInfo/types.tsx
@@ -8,7 +8,7 @@ export interface PlatformMatchParams {
   /**
    * Platform ID from URL parameter
    */
-  id: string
+  platform: PlatformFeature
   sensors?: PlatformFeature[] | undefined
 }
 


### PR DESCRIPTION
Synchronizes `usePlatform` and `useDataset` so the explicit "recent value" in the sidebar reflects the most recent reading taken as seen in the graphed timeseries. This was done to avoid extra calls to ERDDAP and used cached data to our advantage.

Logic for combining happens in: `/Features/ERDDAP/hooks/TableDAPComponents.tsx`

This logic was then used for the rest of the app so all most recent values in main part of app (not just in water level portion) are also updated with most accurate value.

Ex.
<img width="1728" alt="Screenshot 2024-07-26 at 4 01 09 PM" src="https://github.com/user-attachments/assets/f0e98d8b-2872-4b36-b10f-910d458b6bc9">

