### PR TITLE
Fix JSURL import failure

### DIFF
--- a/app/(modelsMap)/models/query-hooks.ts
+++ b/app/(modelsMap)/models/query-hooks.ts
@@ -1,4 +1,4 @@
-import JSURL from "jsurl2"
+import * as JSURL from "jsurl2"
 import { fromLonLat, toLonLat } from "ol/proj"
 import React from "react"
 import { useSearchParams, useRouter, usePathname } from "next/navigation"


### PR DESCRIPTION
JSURL was failing to import with `Attempted import error: 'jsurl2' does not contain a default export (imported as 'JSURL').` which caused the modeling pages to fail to load.