### PR TITLE
Redirects for tide gauges

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,31 @@ const nextConfig = {
   //   disableStaticImages: true
   // }
   output: "standalone",
+  redirects: async () => {
+    return [
+      // Redirects for tide gauge signs https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3011
+      {
+        source: "/s/fore-river-tide-gauge",
+        destination: "/platform/Fore%20River%20Tide%20Gauge",
+        permanent: false,
+      },
+      {
+        source: "/s/machias-tide-gauge",
+        destination: "/platform/Machias%20tide%20gauge",
+        permanent: false,
+      },
+      {
+        source: "/s/boothbay-harbor-tide-gauge",
+        destination: "/platform/Boothbay%20Harbor%20Tide%20Gauge",
+        permanent: false,
+      },
+      {
+        source: "/s/port-clyde-tide-gauge",
+        destination: "/platform/Port%20Clyde%20Tide%20Gauge",
+        permanent: false,
+      },
+    ]
+  },
 }
 
 // Injected content via Sentry wizard below

--- a/tests/e2e/Platform/redirects.spec.ts
+++ b/tests/e2e/Platform/redirects.spec.ts
@@ -1,11 +1,11 @@
-import {expect, test} from "@playwright/test"
+import { expect, test } from "@playwright/test"
 
 test.describe("Platform redirects", () => {
-    // Redirects for tide gauge signs https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3011
-    test("Can redirect to platform page", async ({page}) => {
-        await page.goto("/s/port-clyde-tide-gauge")
-        await expect(await page.getByText("Port Clyde Tide Gauge").first()).toBeVisible()
-        await expect(await page.getByText("Mean Lower Low Water").first()).toBeVisible()
-        await expect(page.url()).toBe("http://127.0.0.1:3000/platform/Port%20Clyde%20Tide%20Gauge")
-    })
+  // Redirects for tide gauge signs https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3011
+  test("Can redirect to platform page", async ({ page }) => {
+    await page.goto("/s/port-clyde-tide-gauge")
+    await expect(await page.getByText("Port Clyde Tide Gauge").first()).toBeVisible()
+    await expect(await page.getByText("Mean Lower Low Water").first()).toBeVisible()
+    await expect(page.url()).toBe("http://127.0.0.1:3000/platform/Port%20Clyde%20Tide%20Gauge")
+  })
 })

--- a/tests/e2e/Platform/redirects.spec.ts
+++ b/tests/e2e/Platform/redirects.spec.ts
@@ -1,0 +1,11 @@
+import {expect, test} from "@playwright/test"
+
+test.describe("Platform redirects", () => {
+    // Redirects for tide gauge signs https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3011
+    test("Can redirect to platform page", async ({page}) => {
+        await page.goto("/s/port-clyde-tide-gauge")
+        await expect(await page.getByText("Port Clyde Tide Gauge").first()).toBeVisible()
+        await expect(await page.getByText("Mean Lower Low Water").first()).toBeVisible()
+        await expect(page.url()).toBe("http://127.0.0.1:3000/platform/Port%20Clyde%20Tide%20Gauge")
+    })
+})


### PR DESCRIPTION
This sets up URLs using Next.js redirect functionality to provide slightly shorter URLs that more importantly are stable (and can be adapted if the naming of the gauges changes, or they should be pointed towards the water level pages instead). 

This should be deployed to the main site before the signs are installed.

Closes #3011