### PR TITLE
Fix SessionStorage error

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,12 +1,12 @@
 "use client"
 import { useState } from "react"
-import { Provider } from "react-redux"
+import dynamic from "next/dynamic"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 import { GAListener } from "Shared/google-analytics"
 
-import { store } from "./store"
+const ReduxStore = dynamic(() => import("./store.tsx"), { ssr: false })
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -23,12 +23,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Provider store={store}>
+      <ReduxStore>
         <GAListener trackingId={process.env.NODE_ENV === "production" ? "G-MVZR2D0XKJ" : undefined}>
           {children}
           <ReactQueryDevtools />
         </GAListener>
-      </Provider>
+      </ReduxStore>
     </QueryClientProvider>
   )
 }

--- a/app/store.tsx
+++ b/app/store.tsx
@@ -40,9 +40,6 @@ function loadFromLocalStorage() {
   }
 }
 
-
 export default function ReduxStore({ children }) {
-  return (
-    <Provider store={store}>{children}</Provider>
-  )
+  return <Provider store={store}>{children}</Provider>
 }

--- a/app/store.tsx
+++ b/app/store.tsx
@@ -1,4 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit"
+import { Provider } from "react-redux"
 
 import { unitReducer as unit } from "Features/Units"
 
@@ -37,4 +38,11 @@ function loadFromLocalStorage() {
     console.error("Could not load state", e)
     return undefined
   }
+}
+
+
+export default function ReduxStore({ children }) {
+  return (
+    <Provider store={store}>{children}</Provider>
+  )
 }


### PR DESCRIPTION
On the server/dev we're getting session storage errors from trying to reload the users Redux preferences.

This is coming from trying to access the client session storage during pre-rendering. This moves the whole Redux provider to be client rendered and blocks server rendering.

```
Could not load state ReferenceError: sessionStorage is not defined
    at /app/.next/server/chunks/487.js:1:4733
    at 42331 (/app/.next/server/chunks/487.js:1:4861)
    at Object.t [as require] (/app/.next/server/webpack-runtime.js:1:143)
    at require (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:16:18490)
    at I (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:94362)
    at C (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:92913)
    at rP (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:33974)
    at nN (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:62304)
    at nB (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)
    at nM (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:58560)
```