### PR TITLE
Fix critical dependency build error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
   experimental: {
     craCompat: false,
     instrumentationHook: true,
+    serverComponentsExternalPackages: ["web-worker"],
   },
   // Remove this to leverage Next.js' static image handling
   // read more here: https://nextjs.org/docs/api-reference/next/image


### PR DESCRIPTION
There was an error being thrown about a dependency during building that didn't stop the build.

```
./node_modules/web-worker/cjs/node.js
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
./node_modules/web-worker/cjs/node.js
./node_modules/geotiff/dist-module/worker/decoder.js
./node_modules/geotiff/dist-module/pool.js
./node_modules/geotiff/dist-module/geotiff.js
./node_modules/ol/source/GeoTIFF.js
./node_modules/ol/source.js
./node_modules/rlayers/dist/layer/RLayerTile.js
./node_modules/rlayers/dist/index.js
./src/Features/ERDDAP/waterLevel/map.tsx
./app/(waterLevel)/water-level/page.tsx
```

xref: https://github.com/vercel/next.js/issues/52876