### PR TITLE
Highcharts accessibility

### DIFF
--- a/app/(modelsMap)/models/chart.tsx
+++ b/app/(modelsMap)/models/chart.tsx
@@ -1,4 +1,5 @@
 import Highcharts from "highcharts"
+import addAccessibility from "highcharts/modules/accessibility"
 import * as React from "react"
 import {
   Chart,
@@ -15,6 +16,8 @@ import { colorCycle } from "Shared/colors"
 import { round } from "Shared/math"
 
 import { LoadedData } from "./types"
+
+addAccessibility(Highcharts)
 
 interface Props {
   loaded: LoadedData[]

--- a/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/largeTimeSeriesChart.tsx
@@ -3,6 +3,7 @@
  * Single large time series chart component
  */
 import Highcharts from "highcharts"
+import addAccessibility from "highcharts/modules/accessibility"
 import {
   Chart,
   Legend,
@@ -26,6 +27,7 @@ import { pointFormatMaker } from "components/Charts/formatter"
 import { getValueWithOffset } from "Features/Units/Converter/data_types/_tidal_level"
 import { displayShortIso, shortestDisplayIso } from "Shared/time"
 
+addAccessibility(Highcharts)
 const plotOptions = {
   time: {
     useUTC: false,

--- a/src/components/Charts/LargeTimeSeries.tsx
+++ b/src/components/Charts/LargeTimeSeries.tsx
@@ -3,6 +3,7 @@
  * Single large time series chart component
  */
 import Highcharts from "highcharts"
+import addAccessibility from "highcharts/modules/accessibility"
 import * as React from "react"
 import { Chart, HighchartsChart, SplineSeries, Tooltip, HighchartsProvider, XAxis, YAxis } from "react-jsx-highcharts"
 
@@ -13,6 +14,8 @@ import { UnitSystem } from "Features/Units/types"
 import { converter } from "Features/Units/Converter"
 
 import { pointFormatMaker } from "./formatter"
+
+addAccessibility(Highcharts)
 
 const plotOptions = {
   time: {

--- a/src/components/Charts/MultipleLargeTimeSeries.tsx
+++ b/src/components/Charts/MultipleLargeTimeSeries.tsx
@@ -2,6 +2,7 @@
  * Time series chart component for displaying multiple sets of time series data
  */
 import Highcharts from "highcharts"
+import addAccessibility from "highcharts/modules/accessibility"
 import * as React from "react"
 import {
   Chart,
@@ -19,6 +20,7 @@ import { colorCycle } from "Shared/colors"
 import { round } from "Shared/math"
 import { DataTimeSeries } from "Shared/timeSeries"
 
+addAccessibility(Highcharts)
 function formatterWrapper(unit) {
   return function pointFormatter(this: any) {
     if (this.point) {

--- a/src/components/Charts/MultipleLargeTimeSeriesCurrent.tsx
+++ b/src/components/Charts/MultipleLargeTimeSeriesCurrent.tsx
@@ -3,6 +3,7 @@
  * Time series chart component for displaying multiple sets of time series data with current time line
  */
 import Highcharts from "highcharts"
+import addAccessibility from "highcharts/modules/accessibility"
 import React, { useEffect, useState } from "react"
 import {
   Chart,
@@ -21,6 +22,7 @@ import { colorCycle } from "Shared/colors"
 import { round } from "Shared/math"
 import { StyledTimeSeries } from "Shared/timeSeries"
 
+addAccessibility(Highcharts)
 function formatterWrapper(unit) {
   return function pointFormatter(this: any) {
     if (this.point) {

--- a/src/components/Charts/SmallTimeSeries.tsx
+++ b/src/components/Charts/SmallTimeSeries.tsx
@@ -2,6 +2,7 @@
  * Small time series chart component (as seen on current conditions page)
  */
 import Highcharts from "highcharts"
+import addAccessibility from "highcharts/modules/accessibility"
 import * as React from "react"
 import { Chart, HighchartsChart, SplineSeries, Tooltip, HighchartsProvider, XAxis, YAxis } from "react-jsx-highcharts"
 
@@ -12,6 +13,7 @@ import { ReadingTimeSeries } from "Shared/timeSeries"
 import { pointFormatMaker } from "./formatter"
 import { UnitSystem } from "Features/Units/types"
 
+addAccessibility(Highcharts)
 const plotOptions = {
   time: {
     useUTC: false,

--- a/src/components/Charts/WindTimeSeries.tsx
+++ b/src/components/Charts/WindTimeSeries.tsx
@@ -4,6 +4,7 @@
  * in addition to wind barbs for wind direction
  */
 import Highcharts from "highcharts"
+import addAccessibility from "highcharts/modules/accessibility"
 import addWindBarbModule from "highcharts/modules/windbarb"
 import * as React from "react"
 import {
@@ -24,6 +25,8 @@ import { colors, colorCycle } from "Shared/colors"
 import { round } from "Shared/math"
 import { DataTimeSeries } from "Shared/timeSeries"
 import { compassDirection } from "Shared/unitConversion/compassDirection"
+
+addAccessibility(Highcharts)
 
 const dataConverter = converter("wind_speed")
 


### PR DESCRIPTION
I noticed a warning in the browser console that Highcharts wasn't loading some of it's accessibility helpers, so lets make sure that happens.
```
Highcharts warning: Consider including the "accessibility.js" module to make your chart more usable for people with disabilities. Set the "accessibility.enabled" option to false to remove this warning. See https://www.highcharts.com/docs/accessibility/accessibility-module.
```