### PR TITLE
Switch prettier pre-commit hook to mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: ["--maxkb=600"]
       - id: no-commit-to-branch
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.3" # Use the sha or tag you want to point at
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.3.3"
     hooks:
       - id: prettier


### PR DESCRIPTION
The prettier pre-commit hook was archived due to some issues, so switching to a fork that is updated.