### PR TITLE
Update queryClient init

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,25 +1,43 @@
 "use client"
-import { useState } from "react"
 import dynamic from "next/dynamic"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 import { GAListener } from "Shared/google-analytics"
 
 const ReduxStore = dynamic(() => import("./store.tsx"), { ssr: false })
 
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+        refetchOnWindowFocus: false,
+      },
+    },
+  })
+}
+
+let browserQueryClient: QueryClient | undefined = undefined
+
+function getQueryClient() {
+  if (isServer) {
+    // Always make a new client on the server
+    return makeQueryClient()
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) {
+      browserQueryClient = makeQueryClient()
+    }
+    return browserQueryClient
+  }
+}
+
 export default function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 60 * 1000,
-            refetchOnWindowFocus: false,
-          },
-        },
-      }),
-  )
+  const queryClient = getQueryClient()
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Updates the React-Query client initialization. It's reccomended not to use `useState` now as that can fall out of sync if something is suspended.

https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr#initial-setup