### PR TITLE
Remove unneeded remote OpenLayers CSS

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,9 +11,6 @@ import "../src/index.scss"
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" style={{ margin: 0, overflow: "none" }}>
-      <head>
-        <link rel="stylesheet" href="https://openlayers.org/en/v5.2.0/css/ol.css" type="text/css" />
-      </head>
       <body>
         <div className="App" style={{ position: "relative", minHeight: "100vh" }}>
           <Providers>

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,6 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" type="image/vnd.microsoft.icon" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/neracoos_favicon.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="stylesheet" href="https://openlayers.org/en/v5.2.0/css/ol.css" type="text/css" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
We were trying to load some CSS from openlayers.org, but is many versions old. The files have been removed and was throwing error in the console.