### PR TITLE
Filter old and future forecasts

### DIFF
--- a/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
+++ b/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
@@ -6,14 +6,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import type { Point } from "geojson"
 import React from "react"
-import { Alert, Row, Col, Tooltip, Badge } from "reactstrap"
+import { Alert, Row, Col, Tooltip } from "reactstrap"
 
 import { MultipleLargeTimeSeriesChartCurrent } from "components/Charts/MultipleLargeTimeSeriesCurrent"
 import { colorCycle } from "Shared/colors"
 import { round } from "Shared/math"
 import { tabledapHtmlUrl } from "Shared/erddap/tabledap"
-import { aDayAgoRounded, calcAnyHourAgoRounded } from "Shared/time"
-import { StyledTimeSeries, ReadingTimeSeries } from "Shared/timeSeries"
+import { aDayAgoRounded, weeksInFuture } from "Shared/time"
+import { StyledTimeSeries } from "Shared/timeSeries"
 import { UnitSystem } from "Features/Units/types"
 import { converter } from "Features/Units/Converter"
 
@@ -69,7 +69,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
   const results = useForecasts(lat, lon, forecasts ?? [])
 
   const aDayAgo = aDayAgoRounded()
-  const twoWeeksFromNow = calcAnyHourAgoRounded(-24 * 14)
+  const twoWeeksFromNow = weeksInFuture(2)
 
   const forecastResults = (forecasts || []).flatMap((f, index) => {
     const result = results[index]

--- a/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
+++ b/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
@@ -81,20 +81,18 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
         return []
       }
 
-      return [{
-        meta: f,
-        data: filteredData,
-        }
+      return [
+        {
+          meta: f,
+          data: filteredData,
+        },
       ]
     }
 
     return []
-  }
-)
+  })
 
   const chartData: UrlStyledTimeSeries[] = []
-
-  
 
   if (dataset && timeSeries) {
     chartData.push({
@@ -109,13 +107,13 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
 
   forecastResults.forEach(({ data, meta }, index) => {
     chartData.push({
-        timeSeries: data,
-        name: meta.name + " - forecast",
-        unit: meta.units,
-        url: meta.source_url,
-        dashStyle: "Solid",
-        color: colorCycle[index + 1],
-      })
+      timeSeries: data,
+      name: meta.name + " - forecast",
+      unit: meta.units,
+      url: meta.source_url,
+      dashStyle: "Solid",
+      color: colorCycle[index + 1],
+    })
   })
 
   const unitSystem = useUnitSystem()
@@ -140,21 +138,19 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
           <h4>
             {forecasts[0].forecast_type} Forecast{" "}
             {forecastResults.length > 0 ? (
-            <ForecastInfo>
-              Data access:
-              <ul style={{ paddingLeft: "1rem" }}>
-                {chartData.map((ts, id) => (
-                  <li key={id}>
-                    <a href={ts.url}>{ts.name}</a>
-                  </li>
-                ))}
-              </ul>
-            </ForecastInfo>
+              <ForecastInfo>
+                Data access:
+                <ul style={{ paddingLeft: "1rem" }}>
+                  {chartData.map((ts, id) => (
+                    <li key={id}>
+                      <a href={ts.url}>{ts.name}</a>
+                    </li>
+                  ))}
+                </ul>
+              </ForecastInfo>
             ) : null}
           </h4>
-          {isPending ? (
-                <Alert color="primary">Loading forecast data...</Alert>
-            ) : null}
+          {isPending ? <Alert color="primary">Loading forecast data...</Alert> : null}
         </div>
 
         <ForecastChart type={forecast_type} unitSystem={unitSystem} data={chartData} />


### PR DESCRIPTION
Currently there are a few rogue forecast points being returned decades into the future for the GFS, and BIO has fallen behind, so this filters out both forecast data more than two weeks ahead or a day behind from being displayed. If a forecast doesn't have data in the time range, it isn't displayed at all.

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/b7724460-509b-4d32-9bcc-c8a47253b21a">

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/e553a5aa-c924-4516-b283-64edb0c317bf">



This also adds an alert when a forecast is still loading.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208442266713391