### PR TITLE
Adelle/wl station name updates

### DIFF
--- a/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
@@ -22,6 +22,29 @@ export default function SensorIdPage({ params }) {
   const [waterLevelPlatforms, setWaterLevelPlatforms] = useState<PlatformFeature[] | undefined>()
   const id = useDecodedUrl(params.sensorId)
 
+  const [currentTime, setCurrentTime] = useState(Date.now())
+
+  useEffect(() => {
+    const updateGraph = () => {
+      setCurrentTime(Date.now())
+    }
+
+    const interval = setInterval(updateGraph, 60 * 1000 * 60) // Update every hour
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        updateGraph()
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [])
+
   useEffect(() => {
     if (data) {
       data.features.forEach((feature) => {

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -50,7 +50,6 @@ export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) 
     name = `${name} @ ${timeSeries.depth}m`
   }
 
-  console.log(timeSeries, name, unitSystem)
   return (
     <React.Fragment>
       <Link

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -50,6 +50,7 @@ export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) 
     name = `${name} @ ${timeSeries.depth}m`
   }
 
+  console.log(timeSeries, name, unitSystem)
   return (
     <React.Fragment>
       <Link

--- a/src/Features/ERDDAP/waterLevel/DatumSelector.tsx
+++ b/src/Features/ERDDAP/waterLevel/DatumSelector.tsx
@@ -41,6 +41,20 @@ export const DatumSelector = ({ datumOffsets }: { datumOffsets: DatumOffsets }) 
           </label>
         )
       })
+      options.push(
+        <label key={`radio-label-navd88`}>
+          <input
+            type="radio"
+            id={`offset-navd88`}
+            value="NAVD88 coming soon"
+            key={`offset-navd88`}
+            checked={false}
+            disabled
+            style={{ marginRight: "5px" }}
+          ></input>
+          NAVD88 (coming soon)
+        </label>,
+      )
       setDatumOptions(options.length ? options : null)
     }
   }, [datumOffsets, datumSelected, startTime, endTime])

--- a/src/Features/ERDDAP/waterLevel/sensorSelector.tsx
+++ b/src/Features/ERDDAP/waterLevel/sensorSelector.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import { Col, Dropdown, DropdownItem, DropdownMenu, DropdownToggle, Row } from "reactstrap"
 import { useDecodedUrl } from "util/hooks"
 import { buildSearchParamsQuery } from "Shared/urlParams"
+import { platformName } from "Features/ERDDAP/utils/platformName"
 
 export const WaterLevelSensorSelector = ({ sensors }) => {
   const [isOpen, setIsOpen] = useState(false)
@@ -37,7 +38,7 @@ export const WaterLevelSensorSelector = ({ sensors }) => {
               }}
               className="list-group-item list-group-item-action"
             >
-              {p.id} {p.properties.station_name ? `- ${p.properties.station_name}` : null}
+              {platformName(p)}
             </Link>
           )
         })
@@ -57,7 +58,7 @@ export const WaterLevelSensorSelector = ({ sensors }) => {
           style={{ border: "1px solid black", borderRadius: "7px" }}
         >
           <DropdownToggle color={"#FFFFFF"} caret={true}>
-            {sensor.id} {sensor.properties.station_name ? `- ${sensor.properties.station_name}` : null}
+            {platformName(sensor)}
           </DropdownToggle>
           {sensorOptions && (
             <DropdownMenu end={true} style={{ padding: 0, border: "1px", maxHeight: "215px", overflow: "scroll" }}>

--- a/src/Features/ERDDAP/waterLevel/sensorSelector.tsx
+++ b/src/Features/ERDDAP/waterLevel/sensorSelector.tsx
@@ -11,7 +11,8 @@ export const WaterLevelSensorSelector = ({ sensors }) => {
   const [sensorOptions, setSensorOptions] = useState()
   const params = useParams()
   const searchParams = useSearchParams()
-  const sensor = sensors.find((s) => s.id === useDecodedUrl(params.sensorId as string))
+  const decodedId = useDecodedUrl(params.sensorId as string)
+  const sensor = sensors.find((s) => s.id === decodedId)
   const endTime = searchParams.get("end")
   const startTime = searchParams.get("start")
 

--- a/src/Features/ERDDAP/waterLevel/sensorSelector.tsx
+++ b/src/Features/ERDDAP/waterLevel/sensorSelector.tsx
@@ -10,7 +10,7 @@ export const WaterLevelSensorSelector = ({ sensors }) => {
   const [sensorOptions, setSensorOptions] = useState()
   const params = useParams()
   const searchParams = useSearchParams()
-  const sensorId = useDecodedUrl(params.sensorId as string)
+  const sensor = sensors.find((s) => s.id === useDecodedUrl(params.sensorId as string))
   const endTime = searchParams.get("end")
   const startTime = searchParams.get("start")
 
@@ -20,21 +20,27 @@ export const WaterLevelSensorSelector = ({ sensors }) => {
 
   useEffect(() => {
     if (sensors) {
-      const options = sensors.map((p, index) => {
-        return (
-          <Link
-            key={`dropdown-${index}`}
-            onClick={() => close()}
-            href={{
-              pathname: `/water-level/sensor/${p.id as string}`,
-              query: buildSearchParamsQuery(startTime as string, endTime as string, "datum_mllw_meters"),
-            }}
-            className="list-group-item list-group-item-action"
-          >
-            {p.id}
-          </Link>
-        )
-      })
+      const options = sensors
+        .sort((a, b) => {
+          if (a.id < b.id) {
+            return -1
+          } else return 1
+        })
+        .map((p, index) => {
+          return (
+            <Link
+              key={`dropdown-${index}`}
+              onClick={() => close()}
+              href={{
+                pathname: `/water-level/sensor/${p.id as string}`,
+                query: buildSearchParamsQuery(startTime as string, endTime as string, "datum_mllw_meters"),
+              }}
+              className="list-group-item list-group-item-action"
+            >
+              {p.id} {p.properties.station_name ? `- ${p.properties.station_name}` : null}
+            </Link>
+          )
+        })
       setSensorOptions(options)
     }
   }, [sensors])
@@ -51,7 +57,7 @@ export const WaterLevelSensorSelector = ({ sensors }) => {
           style={{ border: "1px solid black", borderRadius: "7px" }}
         >
           <DropdownToggle color={"#FFFFFF"} caret={true}>
-            {sensorId}
+            {sensor.id} {sensor.properties.station_name ? `- ${sensor.properties.station_name}` : null}
           </DropdownToggle>
           {sensorOptions && (
             <DropdownMenu end={true} style={{ padding: 0, border: "1px", maxHeight: "215px", overflow: "scroll" }}>

--- a/src/Features/Units/Converter/data_types/_tidal_level.ts
+++ b/src/Features/Units/Converter/data_types/_tidal_level.ts
@@ -14,7 +14,7 @@ export class TidalLevel extends DataTypeConversion {
     public data_type: string,
     public display_name: string,
   ) {
-    super(data_type, display_name, "m", "m", "ft", "Meters", "Feet")
+    super(data_type, display_name, "m", "m", "ft", "Meters", "ft")
   }
 }
 

--- a/src/Features/Units/Converter/data_types/_wave_height.ts
+++ b/src/Features/Units/Converter/data_types/_wave_height.ts
@@ -14,6 +14,6 @@ export class WaveHeight extends DataTypeConversion {
     public data_type: string,
     public display_name: string,
   ) {
-    super(data_type, display_name, "m", "m", "ft", "Meters", "Feet")
+    super(data_type, display_name, "m", "m", "ft", "Meters", "ft")
   }
 }

--- a/src/Features/Units/Converter/data_types/maximum_wave_height.spec.ts
+++ b/src/Features/Units/Converter/data_types/maximum_wave_height.spec.ts
@@ -17,7 +17,7 @@ describe("max_wave_height conversions", () => {
   })
 
   it("display names", () => {
-    expect(max_wave_height.displayName(UnitSystem.english)).toBe("Feet")
+    expect(max_wave_height.displayName(UnitSystem.english)).toBe("ft")
     expect(max_wave_height.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/predicted_sea_water_level.spec.ts
+++ b/src/Features/Units/Converter/data_types/predicted_sea_water_level.spec.ts
@@ -17,7 +17,7 @@ describe("predicted_sea_water_level conversions", () => {
   })
 
   it("display names", () => {
-    expect(predicted_sea_water_level.displayName(UnitSystem.english)).toBe("Feet")
+    expect(predicted_sea_water_level.displayName(UnitSystem.english)).toBe("ft")
     expect(predicted_sea_water_level.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/sea_surface_height_above_geopotential_datum.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_surface_height_above_geopotential_datum.spec.ts
@@ -17,7 +17,7 @@ describe("sea_surface_height_above_geopotential_datum conversions", () => {
   })
 
   it("display names", () => {
-    expect(sea_surface_height_above_geopotential_datum.displayName(UnitSystem.english)).toBe("Feet")
+    expect(sea_surface_height_above_geopotential_datum.displayName(UnitSystem.english)).toBe("ft")
     expect(sea_surface_height_above_geopotential_datum.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/sea_surface_wave_significant_height.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_surface_wave_significant_height.spec.ts
@@ -17,7 +17,7 @@ describe("sea_surface_wave_significant_height conversions", () => {
   })
 
   it("display names", () => {
-    expect(sea_surface_wave_significant_height.displayName(UnitSystem.english)).toBe("Feet")
+    expect(sea_surface_wave_significant_height.displayName(UnitSystem.english)).toBe("ft")
     expect(sea_surface_wave_significant_height.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/sea_water_level.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_water_level.spec.ts
@@ -17,7 +17,7 @@ describe("sea_water_level conversions", () => {
   })
 
   it("display names", () => {
-    expect(sea_water_level.displayName(UnitSystem.english)).toBe("Feet")
+    expect(sea_water_level.displayName(UnitSystem.english)).toBe("ft")
     expect(sea_water_level.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves.spec.ts
+++ b/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves.spec.ts
@@ -17,7 +17,7 @@ describe("significant_height_of_wind_and_swell_waves conversions", () => {
   })
 
   it("display names", () => {
-    expect(significant_height_of_wind_and_swell_waves.displayName(UnitSystem.english)).toBe("Feet")
+    expect(significant_height_of_wind_and_swell_waves.displayName(UnitSystem.english)).toBe("ft")
     expect(significant_height_of_wind_and_swell_waves.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves_3.spec.ts
+++ b/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves_3.spec.ts
@@ -17,7 +17,7 @@ describe("significant_height_of_wind_and_swell_waves_3 conversions", () => {
   })
 
   it("display names", () => {
-    expect(significant_height_of_wind_and_swell_waves_3.displayName(UnitSystem.english)).toBe("Feet")
+    expect(significant_height_of_wind_and_swell_waves_3.displayName(UnitSystem.english)).toBe("ft")
     expect(significant_height_of_wind_and_swell_waves_3.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/significant_wave_height.spec.ts
+++ b/src/Features/Units/Converter/data_types/significant_wave_height.spec.ts
@@ -17,7 +17,7 @@ describe("significant_wave_height conversions", () => {
   })
 
   it("display names", () => {
-    expect(significant_wave_height.displayName(UnitSystem.english)).toBe("Feet")
+    expect(significant_wave_height.displayName(UnitSystem.english)).toBe("ft")
     expect(significant_wave_height.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/surface_altitude.spec.ts
+++ b/src/Features/Units/Converter/data_types/surface_altitude.spec.ts
@@ -17,7 +17,7 @@ describe("surface_altitude conversions", () => {
   })
 
   it("display names", () => {
-    expect(surface_altitude.displayName(UnitSystem.english)).toBe("Feet")
+    expect(surface_altitude.displayName(UnitSystem.english)).toBe("ft")
     expect(surface_altitude.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_higher_high_water.spec.ts
+++ b/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_higher_high_water.spec.ts
@@ -21,7 +21,7 @@ describe("tidal_sea_surface_height_above_mean_higher_high_water conversions", ()
   })
 
   it("display names", () => {
-    expect(tidal_sea_surface_height_above_mean_higher_high_water.displayName(UnitSystem.english)).toBe("Feet")
+    expect(tidal_sea_surface_height_above_mean_higher_high_water.displayName(UnitSystem.english)).toBe("ft")
     expect(tidal_sea_surface_height_above_mean_higher_high_water.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_lower_low_water.spec.ts
+++ b/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_lower_low_water.spec.ts
@@ -21,7 +21,7 @@ describe("tidal_sea_surface_height_above_mean_lower_low_water conversions", () =
   })
 
   it("display names", () => {
-    expect(tidal_sea_surface_height_above_mean_lower_low_water.displayName(UnitSystem.english)).toBe("Feet")
+    expect(tidal_sea_surface_height_above_mean_lower_low_water.displayName(UnitSystem.english)).toBe("ft")
     expect(tidal_sea_surface_height_above_mean_lower_low_water.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_sea_level.spec.ts
+++ b/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_sea_level.spec.ts
@@ -17,7 +17,7 @@ describe("tidal_sea_surface_height_above_mean_sea_level conversions", () => {
   })
 
   it("display names", () => {
-    expect(tidal_sea_surface_height_above_mean_sea_level.displayName(UnitSystem.english)).toBe("Feet")
+    expect(tidal_sea_surface_height_above_mean_sea_level.displayName(UnitSystem.english)).toBe("ft")
     expect(tidal_sea_surface_height_above_mean_sea_level.displayName(UnitSystem.metric)).toBe("Meters")
   })
 })

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -158,7 +158,7 @@ exports[`Storybook Tests ERDDAP/Superlatives Configurable 1`] = `
           <div>
             8.3
              
-            Feet
+            ft
           </div>
           <a
             href="/platform/44008"

--- a/tests/e2e/Home/home.spec.ts
+++ b/tests/e2e/Home/home.spec.ts
@@ -42,6 +42,6 @@ test.describe("Home page", function () {
     await expect(page.getByText(/Highest Winds/).first()).toBeVisible()
     await expect(page.getByText(/Knots/).first()).toBeVisible()
     await expect(page.getByText(/Biggest Waves/).first()).toBeVisible()
-    await expect(page.getByText(/Feet/).first()).toBeVisible()
+    await expect(page.getByText(/ft/).first()).toBeVisible()
   })
 })

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -67,7 +67,7 @@ test.describe("Platfrom 44007", () => {
         .getByText(/Significant Wave Height Forecast/)
         .first(),
     ).toBeVisible()
-    await expect(page.locator("svg.highcharts-root").getByText(/Feet/).first()).toBeVisible()
+    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
     await page
       .getByText(/Metric/)
       .first()
@@ -82,7 +82,7 @@ test.describe("Platfrom 44007", () => {
       .getByText(/English/)
       .first()
       .click()
-    await expect(page.locator("svg.highcharts-root").getByText(/Feet/).first()).toBeVisible()
+    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
     await page
       .getByText(/Wave Height - observations/)
       .first()

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -93,7 +93,7 @@ test.describe("Platform A01", () => {
         .getByText(/Significant Wave Height Forecast/)
         .first(),
     ).toBeVisible()
-    await expect(page.locator("svg.highcharts-root").getByText(/Feet/).first()).toBeVisible()
+    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
     await page
       .getByText(/Metric/)
       .first()
@@ -108,7 +108,7 @@ test.describe("Platform A01", () => {
       .getByText(/English/)
       .first()
       .click()
-    await expect(page.locator("svg.highcharts-root").getByText(/Feet/).first()).toBeVisible()
+    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
     await page
       .getByText(/Significant Wave Height - observations/)
       .first()

--- a/tests/e2e/Platform/m01.spec.ts
+++ b/tests/e2e/Platform/m01.spec.ts
@@ -78,7 +78,7 @@ test.describe.skip("Platfrom M01", () => {
         .getByText(/Significant Wave Height Forecast/)
         .first(),
     ).toBeVisible()
-    await expect(page.locator("svg.highcharts-root").getByText(/Feet/).first()).toBeVisible()
+    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
     await page
       .getByText(/Metric/)
       .first()
@@ -93,7 +93,7 @@ test.describe.skip("Platfrom M01", () => {
       .getByText(/English/)
       .first()
       .click()
-    await expect(page.locator("svg.highcharts-root").getByText(/Feet/).first()).toBeVisible()
+    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
     await page
       .getByText(/Significant Wave Height - observations/)
       .first()

--- a/tests/e2e/WaterSensor/GloucesterHarbor.spec.ts
+++ b/tests/e2e/WaterSensor/GloucesterHarbor.spec.ts
@@ -31,7 +31,7 @@ test.describe("Sensor station at Gloucester Harbor", () => {
   test("Shows platform waterlevel graph", async ({ page }) => {
     await page.goto(platformUrl)
     await page.waitForLoadState("load")
-    await expect(page.locator("svg.highcharts-root").getByText(/Feet/).first()).toBeVisible()
+    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
   })
 
   test("Selects sensor from station selector", async ({ page }) => {


### PR DESCRIPTION
This PR addresses latest tasks in #2860 
- Alphabetizes station names in sensor selection dropdown on sensor page
- Adds long name to sensor selection dropdown. See screenshot.
- Adds NAVD88 as an option for datum changed (it is disabled currently since we don't have it configured in offsets yet). See screenshot.
- Changes Feet to ft in sidebar (to address the case of `1 Feet`)

<img width="657" alt="Screenshot 2024-10-11 at 1 09 42 PM" src="https://github.com/user-attachments/assets/47e158fa-62a8-4955-bd4c-0a9b56fccfe6">
