### PR TITLE
Adelle/time refresh nws links

### DIFF
--- a/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
@@ -8,11 +8,13 @@ import { filterForSensors } from "Features/ERDDAP/waterLevel/sensor"
 
 import { fromLonLat } from "ol/proj"
 import { useEffect, useState } from "react"
-import { Col, Row } from "reactstrap"
+import { Alert, Col, Row } from "reactstrap"
 import { useDecodedUrl } from "util/hooks"
 import { createBreakpoint } from "react-use"
 import { WaterLevelSensorInfo } from "components/PlatformInfo/WaterLevelSensorInfo"
 import { useSearchParams } from "next/navigation"
+import React from "react"
+import { SecondaryBanner } from "components/SecondaryBanner"
 
 const useBreakpoint = createBreakpoint({ S: 576, M: 768, L: 992 })
 
@@ -35,6 +37,14 @@ export default function SensorIdPage({ params }) {
 
   return (
     <div>
+      <SecondaryBanner>
+        <p style={{ fontStyle: "italic", fontSize: "14px", marginBottom: "0px", textAlign: "center" }}>
+          For official watch, warning, advisory, and forecast information please visit the{" "}
+          <a href="https://www.weather.gov/erh/coastalflood" target="_blank">
+            NWS Eastern Region Coastal Flood Page
+          </a>
+        </p>
+      </SecondaryBanner>
       <Row>
         <Col sm={{ size: "6" }} md={{ size: "4" }}>
           {waterLevelPlatforms && <WaterLevelSensorInfo id={id} sensors={waterLevelPlatforms} />}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
@@ -1,4 +1,4 @@
-import { PlatformTimeSeries } from "Features/ERDDAP/types"
+import { DatumOffsetOptions, PlatformTimeSeries } from "Features/ERDDAP/types"
 import { converter } from "Features/Units/Converter"
 import { UnitSystem } from "Features/Units/types"
 import { DataTimeSeries } from "Shared/timeSeries"
@@ -14,9 +14,15 @@ import {
   manuallySetFullEODIso,
   roundDate,
   shortIso,
+  threeDaysAgoRounded,
+  weeksInFuture,
 } from "Shared/time"
 import { round } from "@turf/helpers"
 import { getValueWithOffset } from "Features/Units/Converter/data_types/_tidal_level"
+import { Revert } from "Shared/icons/Revert"
+import { buildSearchParamsQuery } from "Shared/urlParams"
+import Link from "next/link"
+import { Button } from "reactstrap"
 
 interface ChartTimeSeriesDisplayProps {
   dataset: DataTimeSeries
@@ -114,8 +120,31 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
 
   return (
     <div>
-      <h4 style={{ width: "100%", textAlign: "center" }}>{`${title} for Station: ${sensorId}`}</h4>
-      <p style={{ textAlign: "center" }}>{`${displayShortIso(startTime)} - ${displayShortIso(endTime)}`}</p>
+      <div style={{ display: "flex", width: "100%", flexDirection: "column", alignItems: "center" }}>
+        <h4 style={{ width: "100%", textAlign: "center" }}>{`${title} for Station: ${sensorId}`}</h4>
+        <p style={{ textAlign: "center", marginBottom: 0 }}>{`${displayShortIso(startTime)} - ${displayShortIso(
+          endTime,
+        )}`}</p>
+        <Button
+          color="light"
+          outline
+          size="sm"
+          style={{ border: "grey", width: "150px", marginTop: "5px", marginBottom: "5px" }}
+        >
+          <Link
+            href={{
+              pathname: `/water-level/sensor/${params.sensorId}`,
+              query: buildSearchParamsQuery(
+                getIsoForPicker(threeDaysAgoRounded()),
+                getIsoForPicker(weeksInFuture(1)),
+                searchParams.get("datum") as DatumOffsetOptions,
+              ),
+            }}
+          >
+            Reset Timeframe
+          </Link>
+        </Button>
+      </div>
       <LargeTimeSeriesWaterLevelChart
         timeSeries={dataset.timeSeries}
         predictedTidesTimeSeries={predictedTidesDataset?.timeSeries}

--- a/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
@@ -125,25 +125,6 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
         <p style={{ textAlign: "center", marginBottom: 0 }}>{`${displayShortIso(startTime)} - ${displayShortIso(
           endTime,
         )}`}</p>
-        <Button
-          color="light"
-          outline
-          size="sm"
-          style={{ border: "grey", width: "150px", marginTop: "5px", marginBottom: "5px" }}
-        >
-          <Link
-            href={{
-              pathname: `/water-level/sensor/${params.sensorId}`,
-              query: buildSearchParamsQuery(
-                getIsoForPicker(threeDaysAgoRounded()),
-                getIsoForPicker(weeksInFuture(1)),
-                searchParams.get("datum") as DatumOffsetOptions,
-              ),
-            }}
-          >
-            Reset Timeframe
-          </Link>
-        </Button>
       </div>
       <LargeTimeSeriesWaterLevelChart
         timeSeries={dataset.timeSeries}

--- a/src/Features/ERDDAP/waterLevel/observationBase.tsx
+++ b/src/Features/ERDDAP/waterLevel/observationBase.tsx
@@ -80,7 +80,6 @@ export const WaterLevelObservationBase = ({ platform }) => {
               const standardName = waterLevel.data_type.standard_name
 
               return (
-                // <p>hey</p>
                 <div style={{ marginTop: "10px" }}>
                   <WaterLevelChartDisplay
                     {...{ dataset: waterLevelData, standardName, unitSystem }}

--- a/src/Features/ERDDAP/waterLevel/timeframeSelector.tsx
+++ b/src/Features/ERDDAP/waterLevel/timeframeSelector.tsx
@@ -1,5 +1,4 @@
 import { getIsoForPicker, getToday, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
-import queryString from "query-string"
 
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"

--- a/src/components/SecondaryBanner/index.tsx
+++ b/src/components/SecondaryBanner/index.tsx
@@ -1,0 +1,12 @@
+import { Alert } from "reactstrap"
+
+export const SecondaryBanner = ({ children }) => {
+  return (
+    <Alert
+      color="secondary"
+      style={{ padding: "5px", marginRight: "-12px", marginLeft: "-12px", marginTop: "-16px", borderRadius: 0 }}
+    >
+      {children}
+    </Alert>
+  )
+}


### PR DESCRIPTION
- Adds a time refresh button underneath subtitle (timeframe) of wl graph (should merge to dev and have Riley test to make sure user can reset the timeframe)
- Adds a banner with the NWS link at the top

<img width="1726" alt="Screenshot 2024-10-17 at 4 53 26 PM" src="https://github.com/user-attachments/assets/f360d2b7-e99e-4faf-8bdf-ba87899ac9ce">
