### PR TITLE
seperate sensors by region

### DIFF
--- a/app/(waterLevel)/water-level/page.tsx
+++ b/app/(waterLevel)/water-level/page.tsx
@@ -26,9 +26,9 @@ export default function WaterLevelIndexPage() {
 
   const regionCards =
     waterLevelPlatforms &&
-    regionList.map((r) => {
+    regionList.map((r, index) => {
       return (
-        <Card style={{ marginBottom: "20px" }}>
+        <Card style={{ marginBottom: "20px" }} key={`sensor-region-list-#${index}`}>
           <CardHeader>{r.name}</CardHeader>
           <ErddapWaterLevelSensorListBase platforms={waterLevelPlatforms} boundingBox={r.bbox} />
         </Card>

--- a/app/(waterLevel)/water-level/page.tsx
+++ b/app/(waterLevel)/water-level/page.tsx
@@ -6,9 +6,12 @@ import { PlatformFeature } from "Features/ERDDAP/types"
 import { ErddapWaterLevelMapBase } from "Features/ERDDAP/waterLevel/map"
 import { filterForSensors } from "Features/ERDDAP/waterLevel/sensor"
 
-import { Col, Row } from "reactstrap"
+import { Card, CardHeader, Col, Row } from "reactstrap"
 
 import React, { useEffect, useState } from "react"
+import { ErddapPlatformList } from "Features/ERDDAP"
+import { regionList, regions } from "Shared/regions"
+import { ErddapPlatformListBase } from "Features/ERDDAP/List"
 
 export default function WaterLevelIndexPage() {
   const { data, isLoading } = usePlatforms()
@@ -21,6 +24,17 @@ export default function WaterLevelIndexPage() {
     }
   }, [data])
 
+  const regionCards =
+    waterLevelPlatforms &&
+    regionList.map((r) => {
+      return (
+        <Card style={{ marginBottom: "20px" }}>
+          <CardHeader>{r.name}</CardHeader>
+          <ErddapWaterLevelSensorListBase platforms={waterLevelPlatforms} boundingBox={r.bbox} />
+        </Card>
+      )
+    })
+
   return (
     <>
       <Row>
@@ -28,7 +42,10 @@ export default function WaterLevelIndexPage() {
           {waterLevelPlatforms && <ErddapWaterLevelMapBase platforms={waterLevelPlatforms} height={"60vh"} />}
         </Col>
         <Col sm={{ order: "1" }} md={{ order: "2", size: "6" }}>
-          {waterLevelPlatforms && <ErddapWaterLevelSensorListBase platforms={waterLevelPlatforms} />}
+          {/* {waterLevelPlatforms && <ErddapWaterLevelSensorListBase platforms={waterLevelPlatforms} />} */}
+          {regionCards}
+          {/* {waterLevelPlatforms &&
+            regionList.map((r) => <ErddapPlatformListBase platforms={waterLevelPlatforms} boundingBox={r.bbox} />)} */}
         </Col>
       </Row>
     </>

--- a/src/Features/ERDDAP/List/waterSensorList.tsx
+++ b/src/Features/ERDDAP/List/waterSensorList.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { getIsoForPicker, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
 import Link from "next/link"
 import { useEffect, useState } from "react"

--- a/src/Features/ERDDAP/List/waterSensorList.tsx
+++ b/src/Features/ERDDAP/List/waterSensorList.tsx
@@ -1,21 +1,28 @@
 import { getIsoForPicker, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
 import Link from "next/link"
 import { useEffect, useState } from "react"
-import { ListGroup } from "reactstrap"
+import { ListGroup, ListGroupItem } from "reactstrap"
 
 import { platformName } from "../utils/platformName"
 import { PlatformFeature } from "../types"
 import { buildSearchParamsQuery } from "Shared/urlParams"
+import booleanContains from "@turf/boolean-contains"
+import bboxPolygon from "@turf/bbox-polygon"
+import { BoundingBox } from "Shared/regions"
 
 interface Props {
   platforms: PlatformFeature[]
+  boundingBox?: BoundingBox
+  region?: string
 }
 
-export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms }: Props) => {
+export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms, boundingBox }: Props) => {
   const [sensors, setSensors] = useState<PlatformFeature[]>()
 
   useEffect(() => {
-    if (platforms) {
+    if (boundingBox && platforms) {
+      const bbox = boundingBox
+      const polygon = bboxPolygon([bbox.west, bbox.south, bbox.east, bbox.north])
       const listItems = platforms.sort((a, b) => {
         const aId = a.id as string
         const bId = b.id as string
@@ -25,13 +32,20 @@ export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms }: P
           sensitivity: "base",
         })
       })
-      setSensors(listItems)
+      const sensorList = listItems.filter(
+        (platform) =>
+          platform.geometry !== null && booleanContains(polygon, platform as any) && platform.properties !== null,
+      )
+
+      setSensors(sensorList)
     }
   }, [platforms])
 
+  console.log(sensors)
+
   //Station defaults to 3 day in past, week in future, and mllw datum
   return (
-    <ListGroup>
+    <ListGroup flush>
       {sensors &&
         sensors.map((s) => (
           <Link
@@ -49,6 +63,11 @@ export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms }: P
             {platformName(s)}
           </Link>
         ))}
+      {sensors && !sensors?.length && (
+        <ListGroup flush>
+          <ListGroupItem>No sensors available in this region</ListGroupItem>
+        </ListGroup>
+      )}
     </ListGroup>
   )
 }

--- a/src/Features/ERDDAP/List/waterSensorList.tsx
+++ b/src/Features/ERDDAP/List/waterSensorList.tsx
@@ -41,8 +41,6 @@ export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms, bou
     }
   }, [platforms])
 
-  console.log(sensors)
-
   //Station defaults to 3 day in past, week in future, and mllw datum
   return (
     <ListGroup flush>

--- a/src/Shared/regions.ts
+++ b/src/Shared/regions.ts
@@ -116,10 +116,10 @@ export const regions = {
 
 export const regionList: Region[] = [
   GulfOfMaine,
-  LongIslandSound,
   GreatBay,
   Boston,
   CapeCod,
   NarragansettBay,
+  LongIslandSound,
   Newfoundland,
 ]


### PR DESCRIPTION
This addresses a request from Tom/Anna to have the sensors separated by region in water level list page (similar to how platforms are separated in main site) #2860 

![screencapture-localhost-3000-water-level-2024-10-24-15_44_45](https://github.com/user-attachments/assets/65d81235-b564-4d23-bb28-8d6e5ef019bf)
