### PR TITLE
Adelle/sensor page updates

### DIFF
--- a/src/Features/ERDDAP/List/waterSensorList.tsx
+++ b/src/Features/ERDDAP/List/waterSensorList.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { getIsoForPicker, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
+import { daysAgoRounded, daysInFuture, getIsoForPicker, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import { ListGroup, ListGroupItem } from "reactstrap"
@@ -52,8 +52,8 @@ export const ErddapWaterLevelSensorListBase: React.FC<Props> = ({ platforms, bou
             href={{
               pathname: `water-level/sensor/${s.id}`,
               query: buildSearchParamsQuery(
-                getIsoForPicker(threeDaysAgoRounded()),
-                getIsoForPicker(weeksInFuture(1)),
+                getIsoForPicker(daysAgoRounded(2)),
+                getIsoForPicker(daysInFuture(3)),
                 "datum_mllw_meters",
               ),
             }}

--- a/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
+++ b/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
@@ -77,9 +77,9 @@ export const WLPlatformLayer = ({ platform, selected, old = false }: PlatformLay
   const [display, setDisplay] = useState("grey")
   let radius: number
   if (selected) {
-    radius = window.innerWidth > adjustPxWidth ? 12 : 17
+    radius = window.innerWidth > adjustPxWidth ? 10 : 15
   } else {
-    radius = window.innerWidth > adjustPxWidth ? 7 : 12
+    radius = window.innerWidth > adjustPxWidth ? 5 : 10
   }
   const isSensorPage = path.includes("sensor")
 
@@ -137,10 +137,10 @@ const Layer = ({ platform, url, router, radius, color, floodThreshold }) => {
     <RLayerVector zIndex={10} key={key}>
       {color && (
         <RStyle.RStyle>
-          <RStyle.RRegularShape radius={radius} points={4} angle={2.35}>
+          <RStyle.RCircle radius={radius}>
             <RStyle.RFill color={color} />
             <RStyle.RStroke color={"000000"} width={0.5} />
-          </RStyle.RRegularShape>
+          </RStyle.RCircle>
         </RStyle.RStyle>
       )}
 

--- a/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
+++ b/src/Features/ERDDAP/Map/WLPlatformLayer.tsx
@@ -14,7 +14,14 @@ import { BoundingBox, InitialRegion, regionList } from "Shared/regions"
 import { EsriOceanBasemapLayer, EsriOceanReferenceLayer } from "components/Map"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 
-import { aDayAgoRounded, getIsoForPicker, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
+import {
+  aDayAgoRounded,
+  daysAgoRounded,
+  daysInFuture,
+  getIsoForPicker,
+  threeDaysAgoRounded,
+  weeksInFuture,
+} from "Shared/time"
 import { buildSearchParamsQuery } from "Shared/urlParams"
 import { useParams } from "next/navigation"
 import { usePlatforms } from "../hooks"
@@ -99,11 +106,7 @@ export const WLPlatformLayer = ({ platform, selected, old = false }: PlatformLay
         searchParams.get("end") as string,
         searchParams.get("datum") as DatumOffsetOptions,
       )
-    : buildSearchParamsQuery(
-        getIsoForPicker(threeDaysAgoRounded()),
-        getIsoForPicker(weeksInFuture(1)),
-        "datum_mllw_meters",
-      )
+    : buildSearchParamsQuery(getIsoForPicker(daysAgoRounded(2)), getIsoForPicker(daysInFuture(3)), "datum_mllw_meters")
 
   return (
     <div style={{ zIndex: 10 }}>

--- a/src/Shared/time.ts
+++ b/src/Shared/time.ts
@@ -166,6 +166,14 @@ export function threeDaysAgoRounded(): Date {
   return threeDaysAgo
 }
 
+export function daysAgoRounded(numberOfDays): Date {
+  const daysAgo = new Date(Date.now() - DAY * numberOfDays)
+
+  roundDate(daysAgo)
+
+  return daysAgo
+}
+
 /**
  * Get a date that is a week previous
  */


### PR DESCRIPTION
This addresses some sensor page updates requested by Tom and Anna:
- Decreases the default x-axis timeframe to 2 days previous and 3 days in future
- Changes maps icons from squares to circles

![Screenshot 2024-10-28 at 10 44 01 AM](https://github.com/user-attachments/assets/c7296e41-faee-4554-bf42-8b5f2b6d7bee)
