### PR TITLE
Adelle/fix invisible flood thresholds

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: reporters,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  expect: { timeout: 10_000 },
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: "http://127.0.0.1:3000",

--- a/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
+++ b/src/Features/ERDDAP/Platform/Forecasts/Page/index.tsx
@@ -106,7 +106,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
     })
   }
 
-  forecastResults.forEach(({ data, meta }, index) => {
+  forecastResults?.forEach(({ data, meta }, index) => {
     chartData.push({
       timeSeries: data,
       name: meta.name + " - forecast",
@@ -118,19 +118,20 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
   })
 
   const unitSystem = useUnitSystem()
-
-  const isPending = results.some((r) => r.isPending)
-  if (forecasts === undefined || forecasts.length < 1 || (isPending === false && forecastResults.length < 1)) {
+  const isPending = results.some((r) => r.isLoading)
+  if (forecasts === undefined || forecasts?.length < 1 || (isPending === false && forecastResults?.length < 1)) {
     return (
       <Row>
         <Col>
           <WarningAlert>
-            <h4>No forecast available for {forecast_type}</h4>
+            <h4>No current forecast available for {forecast_type}</h4>
           </WarningAlert>
         </Col>
       </Row>
     )
   }
+
+  // console.log("forecasts: ", forecasts, "Pending: ", isPending, "Forecast Results: ", forecastResults)
 
   return (
     <Row>
@@ -138,7 +139,7 @@ export const Forecast = ({ platform, forecast_type, ...props }: Props) => {
         <div style={{ textAlign: "center" }}>
           <h4>
             {forecasts[0].forecast_type} Forecast{" "}
-            {forecastResults.length > 0 ? (
+            {forecastResults?.length > 0 ? (
               <ForecastInfo>
                 Data access:
                 <ul style={{ paddingLeft: "1rem" }}>

--- a/src/Features/ERDDAP/TimeframeSelector/index.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/index.tsx
@@ -12,13 +12,13 @@ import { DatumOffsetOptions } from "../types"
 
 export const TimeframeSelector = ({ graphFuture }: { graphFuture: boolean }) => {
   const pathname = usePathname()
-  const params = useParams()
   const searchParams = useSearchParams()
   const isWaterLevel = pathname.includes("water-level")
   const [startTime, setStartTime] =
     useState<any>(searchParams.get("start")) || getIsoForPicker(isWaterLevel ? daysAgoRounded(2) : aWeekAgoRounded())
   const [endTime, setEndTime] =
-    useState<any>(searchParams.get("end")) || getIsoForPicker(isWaterLevel ? daysInFuture(3) : daysInFuture(0))
+    useState<any>(searchParams.get("end")) ||
+    getIsoForPicker(!isWaterLevel ? daysInFuture(0) : graphFuture ? daysInFuture(3) : daysInFuture(0))
   const [validDateMessage, setValidDateMessage] = useState<string>("")
 
   const validateTimeframe = (start, end) => {
@@ -50,8 +50,11 @@ export const TimeframeSelector = ({ graphFuture }: { graphFuture: boolean }) => 
 
   useEffect(() => {
     setStartTime(searchParams.get("start") || getIsoForPicker(isWaterLevel ? daysAgoRounded(2) : aWeekAgoRounded()))
-    setEndTime(searchParams.get("end") || getIsoForPicker(isWaterLevel ? daysInFuture(3) : daysInFuture(0)))
-  }, [searchParams, isWaterLevel])
+    setEndTime(
+      searchParams.get("end") ||
+        getIsoForPicker(!isWaterLevel ? daysInFuture(0) : graphFuture ? daysInFuture(3) : daysInFuture(0)),
+    )
+  }, [searchParams, isWaterLevel, graphFuture, pathname])
 
   return (
     <Card className={`${isWaterLevel ? "timeframe-card" : "timeframe-card main"}`}>
@@ -102,7 +105,7 @@ export const TimeframeSelector = ({ graphFuture }: { graphFuture: boolean }) => 
               href={
                 searchParams.get("datum")
                   ? {
-                      pathname: `${pathname}${params.sensorId}`,
+                      pathname: `${pathname}`,
                       query: buildSearchParamsQuery("", "", searchParams.get("datum") as DatumOffsetOptions),
                     }
                   : pathname

--- a/src/Features/ERDDAP/TimeframeSelector/index.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/index.tsx
@@ -53,10 +53,6 @@ export const TimeframeSelector = ({ graphFuture }: { graphFuture: boolean }) => 
     setEndTime(searchParams.get("end") || getIsoForPicker(isWaterLevel ? daysInFuture(3) : daysInFuture(0)))
   }, [searchParams, isWaterLevel])
 
-  // useEffect(() => {
-  //   setEndTime(searchParams.get("end") || getIsoForPicker(isWaterLevel ? daysInFuture(3) : daysInFuture(0)))
-  // }, [searchParams.get("end")])
-
   return (
     <Card className={`${isWaterLevel ? "timeframe-card" : "timeframe-card main"}`}>
       {validDateMessage !== "" && <WarningAlert>{validDateMessage}</WarningAlert>}

--- a/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
+++ b/src/Features/ERDDAP/waterLevel/chart/chartDisplay.tsx
@@ -96,6 +96,8 @@ export const WaterLevelChartDisplay: React.FunctionComponent<ChartTimeSeriesDisp
       const datum = searchParams.get("datum") as string
       const offsetName = Object.keys(timeSeries.datum_offsets).find((d) => d.includes(datum.toLowerCase()))
       offsetName && setDatumOffset(timeSeries.datum_offsets[offsetName])
+    } else {
+      setDatumOffset(timeSeries.datum_offsets["datum_mllw_meters"])
     }
   }, [searchParams, timeSeries])
 

--- a/src/Features/ERDDAP/waterLevel/observationBase.tsx
+++ b/src/Features/ERDDAP/waterLevel/observationBase.tsx
@@ -54,12 +54,12 @@ export const WaterLevelObservationBase = ({ platform }) => {
       router.push(`${pathname}?${queryString.stringify(newParams as any)}`)
     }
     if (!predictedTidesTimeseries) {
-      const newParams = buildSearchParamsQuery(
-        getIsoForPicker(startTime),
-        new Date(getToday()).getTime() > endTime.getTime() ? getIsoForPicker(endTime) : getToday(),
-        searchParams.get("datum") as DatumOffsetOptions,
-      )
-      router.push(`${pathname}?${queryString.stringify(newParams as any)}`)
+      // const newParams = buildSearchParamsQuery(
+      //   getIsoForPicker(startTime),
+      //   new Date(getToday()).getTime() > endTime.getTime() ? getIsoForPicker(endTime) : getToday(),
+      //   searchParams.get("datum") as DatumOffsetOptions,
+      // )
+      // router.push(`${pathname}?${queryString.stringify(newParams as any)}`)
     }
     setPredictedTides(predictedTidesTimeseries)
   }, [platform])

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -26,7 +26,7 @@ test.describe("Platfrom 44007", () => {
     await expect(page.getByText(/Latest Conditions/).first()).toBeVisible()
     await expect(page.getByText(/Winds -/).first()).toBeVisible()
 
-    await expect(page.getByText("Loading data").first()).toBeHidden()
+    await expect(page.getByText("Loading").first()).toBeHidden()
 
     const cards = await page.locator(".card")
     await expect(await cards.count()).toBeGreaterThan(3)

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -67,7 +67,9 @@ test.describe("Platfrom 44007", () => {
         .getByText(/Significant Wave Height Forecast/)
         .first(),
     ).toBeVisible()
-    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
+    await expect(
+      page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
+    ).toBeVisible()
     await page
       .getByText(/Metric/)
       .first()
@@ -76,13 +78,16 @@ test.describe("Platfrom 44007", () => {
       page
         .locator("svg.highcharts-root")
         .getByText(/Meters/)
-        .first(),
+        .first()
+        .or(page.getByText("No current forecast available")),
     ).toBeVisible()
     await page
       .getByText(/English/)
       .first()
       .click()
-    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
+    await expect(
+      page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
+    ).toBeVisible()
     await page
       .getByText(/Wave Height - observations/)
       .first()

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -65,7 +65,8 @@ test.describe("Platfrom 44007", () => {
       page
         .locator("h4")
         .getByText(/Significant Wave Height Forecast/)
-        .first(),
+        .first()
+        .or(page.getByText("No current forecast available")),
     ).toBeVisible()
     await expect(
       page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
@@ -88,10 +89,14 @@ test.describe("Platfrom 44007", () => {
     await expect(
       page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
     ).toBeVisible()
-    await page
-      .getByText(/Wave Height - observations/)
-      .first()
-      .click()
+    if (await page.getByText(/Wave Height - observations/).isVisible()) {
+      await page
+        .getByText(/Wave Height - observations/)
+        .first()
+        .click()
+    } else {
+      await expect(page.getByText("No current forecast available")).toBeVisible()
+    }
 
     // await page.locator('svg.highcharts-root').getByText(/Bedford Institute Wave Model - Height/).click()
     // await page.locator('svg.highcharts-root').getByText('Northeast Coastal Ocean Forecast System').click()

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -93,7 +93,9 @@ test.describe("Platform A01", () => {
         .getByText(/Significant Wave Height Forecast/)
         .first(),
     ).toBeVisible()
-    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
+    await expect(
+      page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
+    ).toBeVisible()
     await page
       .getByText(/Metric/)
       .first()
@@ -102,13 +104,16 @@ test.describe("Platform A01", () => {
       page
         .locator("svg.highcharts-root")
         .getByText(/Meters/)
-        .first(),
+        .first()
+        .or(page.getByText("No current forecast available")),
     ).toBeVisible()
     await page
       .getByText(/English/)
       .first()
       .click()
-    await expect(page.locator("svg.highcharts-root").getByText(/ft/).first()).toBeVisible()
+    await expect(
+      page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
+    ).toBeVisible()
     await page
       .getByText(/Significant Wave Height - observations/)
       .first()

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -31,7 +31,7 @@ test.describe("Platform A01", () => {
     await expect(page.getByText(/Latest Conditions/).first()).toBeVisible()
     await expect(page.getByText(/Air Temperature -/).first()).toBeVisible()
 
-    await expect(page.getByText("Loading data").first()).toBeHidden()
+    await expect(page.getByText("Loading").first()).toBeHidden()
 
     const cards = await page.locator(".card")
     await expect(await cards.count()).toBeGreaterThan(4)

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -91,7 +91,8 @@ test.describe("Platform A01", () => {
       page
         .locator("h4")
         .getByText(/Significant Wave Height Forecast/)
-        .first(),
+        .first()
+        .or(page.getByText("No current forecast available")),
     ).toBeVisible()
     await expect(
       page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
@@ -114,10 +115,14 @@ test.describe("Platform A01", () => {
     await expect(
       page.locator("svg.highcharts-root").getByText(/ft/).first().or(page.getByText("No current forecast available")),
     ).toBeVisible()
-    await page
-      .getByText(/Significant Wave Height - observations/)
-      .first()
-      .click()
+    if (await page.getByText(/Significant Wave Height - observations/).isVisible()) {
+      await page
+        .getByText(/Significant Wave Height - observations/)
+        .first()
+        .click()
+    } else {
+      await expect(page.getByText("No current forecast available")).toBeVisible()
+    }
 
     // await page.locator('svg.highcharts-root').getByText(/Bedford Institute Wave Model - Height/).click()
     // await page.locator('svg.highcharts-root').getByText('Northeast Coastal Ocean Forecast System').click()

--- a/tests/e2e/Platform/m01.spec.ts
+++ b/tests/e2e/Platform/m01.spec.ts
@@ -29,7 +29,7 @@ test.describe.skip("Platfrom M01", () => {
     await expect(page.getByText(/Latest Conditions/).first()).toBeVisible()
     await expect(page.getByText(/Air Temperature -/).first()).toBeVisible()
 
-    await expect(page.getByText("Loading data").first()).toBeHidden()
+    await expect(page.getByText("Loading").first()).toBeHidden()
 
     const cards = await page.locator(".card")
     await expect(await cards.count()).toBeGreaterThan(3)


### PR DESCRIPTION
This fixes a few things that I saw were missing last week:
- We lost flood thresholds when I shortened the url, so this adds them back with the default datum
- Tide gauges without ability to convert datums still had the long url with all the search params as a default link--this removes those search params as a default and switches the the new short url pattern.
   - This additionally clears the datum search param when: a user changes the datum on a platform that has datum conversation and then clicks on a gauge that does not have datum conversions (previously it was keeping the datum search params in the url, but was still showing data for navd88 which is misleading.)
 