### PR TITLE
Show the native datum when the current isn't available 

### DIFF
--- a/src/Features/ERDDAP/types.ts
+++ b/src/Features/ERDDAP/types.ts
@@ -177,6 +177,23 @@ export enum Datums {
 }
 export const DATUM_MLLW_METERS = Datums.MLLW
 
+export const StandardNameDatums = {
+  // "sea_water_level",
+  sea_surface_height_above_geopotential_datum: Datums.NAVD88,
+  sea_surface_height_above_mean_sea_level: Datums.MSL,
+  sea_surface_height_above_sea_level: Datums.MSL,
+  // "sea_surface_height",
+  sea_surface_height_above_geoid: Datums.NAVD88,
+  sea_surface_height_above_reference_ellipsoid: Datums.NAVD88,
+  tidal_sea_surface_height_above_lowest_astronomical_tide: Datums.MLLW,
+  tidal_sea_surface_height_above_mean_higher_high_water: Datums.MHHW,
+  tidal_sea_surface_height_above_mean_lower_low_water: Datums.MLLW,
+  // "tidal_sea_surface_height_above_mean_low_water_springs",
+  tidal_sea_surface_height_above_mean_sea_level: Datums.MSL,
+  // "sea_surface_elevation_anomaly",
+  // "sea_surface_elevation",
+}
+
 export type DatumOffsetOptions =
   | "datum_mhhw_meters"
   | "datum_mhw_meters"

--- a/src/Features/ERDDAP/waterLevel/observationContent.tsx
+++ b/src/Features/ERDDAP/waterLevel/observationContent.tsx
@@ -9,30 +9,16 @@ import { DataTimeSeries } from "Shared/timeSeries"
 
 import { filterTimeSeries, filterSingleTimeSeries } from "../Platform/Observations/CurrentConditions"
 import { UseDatasets } from "../hooks"
-import { PlatformFeature, PlatformTimeSeries, Datums } from "../types"
+import { PlatformFeature, PlatformTimeSeries } from "../types"
 import { conditions } from "../utils/conditions"
-import { filterWaterLevelTimeSeries } from "../Platform/Observations/CurrentConditions/waterLevel"
-import { useEndTime, useStartTime, useDatum } from "./hooks"
+import { useEndTime, useStartTime, useWaterLevelDatum } from "./hooks"
 
 export function WaterLevelObservationContent({ platform }: { platform: PlatformFeature }) {
   const unitSystem = useUnitSystem()
   // const pathname = usePathname()
   const { startTime } = useStartTime(true)
   const { endTime } = useEndTime()
-  const { datum } = useDatum()
-
-  // const router = useRouter()
-  // const windowWidth = window.innerWidth
-  const waterLevel = filterWaterLevelTimeSeries(platform.properties.readings, conditions.waterLevel, startTime)
-
-  let datumOffset: number | undefined
-  if (waterLevel) {
-    if (datum === Datums.NAVD88) {
-      datumOffset = 0
-    } else {
-      datumOffset = waterLevel.datum_offsets[datum]
-    }
-  }
+  const { datum, datumOffset, waterLevel } = useWaterLevelDatum(platform, startTime)
 
   const predictedTides = filterSingleTimeSeries(
     platform.properties.readings,


### PR DESCRIPTION
Previously it would think that an otherwise unspecified datum was always MLLW even if that offset wasn't available for a dataset.