### PR TITLE
Some water level fixes

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/WaterLevel/WLErddapObservationTable.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WaterLevel/WLErddapObservationTable.tsx
@@ -8,6 +8,7 @@ import { DatumOffsets } from "Features/ERDDAP/types"
 import { DatumSelector } from "Features/ERDDAP/waterLevel/DatumSelector"
 import { platformName } from "Features/ERDDAP/utils/platformName"
 import { UnitSystem } from "Features/Units/types"
+import { WATER_LEVEL_STANDARDS } from "Shared/constants/standards"
 
 import { UsePlatformRenderProps } from "../../../hooks/BuoyBarnComponents"
 import { currentConditionsTimeseries, filterTimeSeries } from "../../../utils/currentConditionsTimeseries"
@@ -42,7 +43,7 @@ export const WLErddapObservationTable: React.FC<Props> = ({
 
   const waterLevelTimeseries = filterTimeSeries(
     platform.properties.readings.filter((ts) => ts.highlighted === "No"),
-    ["tidal_sea_surface_height_above_mean_lower_low_water"],
+    WATER_LEVEL_STANDARDS,
     laterThan,
   )
 

--- a/src/Shared/constants/standards.ts
+++ b/src/Shared/constants/standards.ts
@@ -1,4 +1,5 @@
 export const WATER_LEVEL_STANDARDS = [
+  "sea_surface_height_above_geopotential_datum",
   "tidal_sea_surface_height_above_mean_higher_high_water",
   "tidal_sea_surface_height_above_mean_lower_low_water",
   "tidal_sea_surface_height_above_mean_sea_level",


### PR DESCRIPTION
This doesn't fix the that some stations don't have their flood thresholds calculating appropriately, but it adds and makes NAVD88 the default water level data source when accessible.



Works on #3514