### PR TITLE
Bringing back the nav icon

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -39,7 +39,7 @@ function NavLink({ href, children }: { href: string; children: React.ReactNode }
 const NeracoosNavBar = () => {
   return (
     <div>
-      <Navbar bg="primary" data-bs-theme="primary" expand="md">
+      <Navbar bg="primary" data-bs-theme="dark" expand="md">
         <Navbar.Brand href={paths.neracoos}>
           <Image src={neracoosLogo} alt="NERACOOS" height={30} />
         </Navbar.Brand>

--- a/src/index.scss
+++ b/src/index.scss
@@ -48,6 +48,9 @@ nav.navbar {
   background-color: $primary;
   margin-bottom: 1rem;
 
+  .dropdown-menu {
+    background-color: white;
+  }
   .navbar-brand > img {
     height: 30px;
   }


### PR DESCRIPTION
The switch to React-Bootstrap also cause a few tweaks to the theme that didn't get caught on mobile. Mainly the menu icon became near invisible, so lets bring that back.

What it looked like:

![image](https://github.com/user-attachments/assets/b232cbd5-287d-4122-b38f-d11f5241d185)


Fixed

![image](https://github.com/user-attachments/assets/0bd781a3-eb6f-446f-9ae2-fac0ac7b5e33)
