### PR TITLE
Release 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ Fixes:
 
 Dependency updates:
 
-## 1.0.8 - 04/17/2024
+## 1.0.9 - 04/18/2025
+
+Fixes:
+
+- Bringing back the nav icon by @abkfenris in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3541
+
+Dependency updates:
+
+- Bump @playwright/test from 1.51.1 to 1.52.0 by @dependabot in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3540
+- Bump @reduxjs/toolkit from 2.6.1 to 2.7.0 in the redux group by @dependabot in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3538
+- Bump the react-query group with 2 updates by @dependabot in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3537
+
+**Full Changelog**: https://github.com/gulfofmaine/Neracoos-1-Buoy-App/compare/v1.0.8...v1.0.9
+
+## 1.0.8 - 04/17/2025
 
 Fixes:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "src",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "src",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "dependencies": {
         "@bprogress/next": "^3.2.12",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -13904,9 +13904,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
-      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "src",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "homepage": "http://mariners.neracoos.org/",
   "dependencies": {


### PR DESCRIPTION
Fixes:

* Bringing back the nav icon by @abkfenris in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3541

Dependency updates:

* Bump @playwright/test from 1.51.1 to 1.52.0 by @dependabot in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3540
* Bump @reduxjs/toolkit from 2.6.1 to 2.7.0 in the redux group by @dependabot in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3538
* Bump the react-query group with 2 updates by @dependabot in https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/3537


**Full Changelog**: https://github.com/gulfofmaine/Neracoos-1-Buoy-App/compare/v1.0.8...v1.0.9