### PR TITLE
Switch unit tests to run on a platform with current data

### DIFF
--- a/tests/e2e/Units/units.spec.ts
+++ b/tests/e2e/Units/units.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test"
 
 /*global cy*/
 
-const platformUrl = "/platform/44007"
+const platformUrl = "/platform/A01"
 
 test.describe("Units", () => {
   test("Switching units updates units displayed", async ({ page }) => {


### PR DESCRIPTION
44007 hasn’t had recent data, so switching the unit selector tests to run against A01.