### PR TITLE
groundwork for getting top 2 obs inside map hover

### DIFF
--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -16,6 +16,7 @@ import { paths } from "Shared/constants"
 import { BoundingBox, InitialRegion, regionList } from "Shared/regions"
 import { EsriOceanBasemapLayer, EsriOceanReferenceLayer } from "components/Map"
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { PlatformInfoLite } from "components/PlatformInfo/platformInfo"
 
 import { aDayAgoRounded, formatDate, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
 import { urlPartReplacer } from "Shared/urlParams"
@@ -114,7 +115,7 @@ export const PlatformLayer = ({ platform, selected, old = false }: PlatformLayer
               [router, url],
             )}
           >
-            {platformName(platform)}
+            <PlatformInfoLite id={platform.id} />
           </Button>
         </RPopup>
       </RFeature>

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -46,10 +46,8 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
 
 export const ErddapPlatformInfoLite: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
   return (
-    <Card role="complementary">
-      <Card.Body>
-        <Card.Title role="header">Station {platformName(platform)}</Card.Title>
-      </Card.Body>
-    </Card>
+    <React.Fragment>
+      Station {platformName(platform)}
+    </React.Fragment>
   )
 }

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -43,3 +43,13 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
     </Card>
   )
 }
+
+export const ErddapPlatformInfoLite: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
+  return (
+    <Card role="complementary">
+      <Card.Body>
+        <Card.Title role="header">Station {platformName(platform)}</Card.Title>
+      </Card.Body>
+    </Card>
+  )
+}

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -22,6 +22,7 @@ interface TableItemProps {
   platform: PlatformFeature
   timeSeries: PlatformTimeSeries
   unitSystem: UnitSystem
+  useShortNameThreshold?: number
 }
 
 type TableItemDisplayProps = Pick<TableItemProps, "timeSeries" | "unitSystem"> &
@@ -47,10 +48,14 @@ const TableItemDisplay: React.FC<TableItemDisplayProps> = ({
   )
 }
 
-export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) => {
+export const TableItem = ({ timeSeries, unitSystem, platform, useShortNameThreshold }: TableItemProps) => {
   const tooltipId = `${timeSeries.data_type.standard_name}-tooltip`
 
   let name = timeSeries.data_type.long_name
+  if (typeof useShortNameThreshold !== 'undefined') {
+    name = (name.length > useShortNameThreshold ? timeSeries.data_type.short_name : name) || name;
+  }
+
   if (timeSeries.depth && timeSeries.depth > 0) {
     name = `${name} @ ${timeSeries.depth}m`
   }

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -18,6 +18,7 @@ interface Props extends UsePlatformRenderProps {
   laterThan: Date
   limit?: number
   children?: any
+  useShortNameThreshold?: number
 }
 
 /**
@@ -31,6 +32,7 @@ export const ErddapObservationTable: React.FC<Props> = ({
   laterThan,
   limit,
   children,
+  useShortNameThreshold,
 }: Props) => {
   let { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, laterThan)
   if (typeof limit !== "undefined") {
@@ -56,7 +58,7 @@ export const ErddapObservationTable: React.FC<Props> = ({
         <ListGroup.Item style={itemStyle}>There is no recent data from {platformName(platform)}</ListGroup.Item>
       )}
       {allCurrentConditionsTimeseries.map((timeSeries, index) => {
-        return <TableItem key={index} timeSeries={timeSeries} platform={platform} unitSystem={unitSystem} />
+        return <TableItem key={index} timeSeries={timeSeries} platform={platform} unitSystem={unitSystem} useShortNameThreshold={useShortNameThreshold}/>
       })}
 
       {unitSelector ? (

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -16,6 +16,7 @@ interface Props extends UsePlatformRenderProps {
   unitSelector?: React.ReactNode
   unitSystem: UnitSystem
   laterThan: Date
+  limit?: number
   children?: any
 }
 
@@ -28,9 +29,13 @@ export const ErddapObservationTable: React.FC<Props> = ({
   unitSelector,
   unitSystem,
   laterThan,
+  limit,
   children,
 }: Props) => {
-  const { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, laterThan)
+  let { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, laterThan)
+  if (typeof limit !== "undefined") {
+    allCurrentConditionsTimeseries = allCurrentConditionsTimeseries.slice(0, limit)
+  }
   const times = allCurrentConditionsTimeseries.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
   times.sort((a, b) => a.valueOf() - b.valueOf())
 

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -1,5 +1,6 @@
 "use client"
 import React from "react"
+import Card from "react-bootstrap/Card"
 
 import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
 import { ErddapPlatformInfoPanel, ErddapPlatformInfoLite } from "Features/ERDDAP/Platform/Info"
@@ -44,13 +45,16 @@ export const PlatformInfoLite = ({ id }: { id: string }) => {
   return (
     <UsePlatform platformId={id}>
       {({ platform }) => (
-        <React.Fragment>
-          <div>
-            <PlatformAlerts platform={platform} />
-            <ErddapPlatformInfoLite platform={platform} />
-            <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
-          </div>
-        </React.Fragment>
+        <Card role="complementary">
+          <Card.Body>
+            <Card.Title role="header">
+              <ErddapPlatformInfoLite platform={platform} />
+            </Card.Title>
+            <Card.Text>
+              <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
+            </Card.Text>
+          </Card.Body>
+        </Card>
       )}
     </UsePlatform>
   )

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -51,7 +51,7 @@ export const PlatformInfoLite = ({ id }: { id: string }) => {
               <ErddapPlatformInfoLite platform={platform} />
             </Card.Title>
             <Card.Text>
-              <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
+              <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} useShortNameThreshold={50}/>
             </Card.Text>
           </Card.Body>
         </Card>

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -2,7 +2,7 @@
 import React from "react"
 
 import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
-import { ErddapPlatformInfoPanel } from "Features/ERDDAP/Platform/Info"
+import { ErddapPlatformInfoPanel, ErddapPlatformInfoLite } from "Features/ERDDAP/Platform/Info"
 import { ErddapObservationTable } from "Features/ERDDAP/Platform/Observations/Table/table"
 import { UsePlatform } from "Features/ERDDAP/hooks/BuoyBarnComponents"
 
@@ -28,6 +28,28 @@ export const PlatformInfo = ({ id }: { id: string }) => {
             unitSystem={unitSystem}
             laterThan={aDayAgo}
           />
+        </React.Fragment>
+      )}
+    </UsePlatform>
+  )
+}
+
+/**
+ * A lightweight version of the platform info panel and w/ only a max # of obs.
+ */
+export const PlatformInfoLite = ({ id }: { id: string }) => {
+  const unitSystem = useUnitSystem()
+  const aDayAgo = aDayAgoRounded()
+
+  return (
+    <UsePlatform platformId={id}>
+      {({ platform }) => (
+        <React.Fragment>
+          <div>
+            <PlatformAlerts platform={platform} />
+            <ErddapPlatformInfoLite platform={platform} />
+            <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
+          </div>
         </React.Fragment>
       )}
     </UsePlatform>


### PR DESCRIPTION
#3876

### NOT READY FOR MERGE

@shindelr 

Reusing as much as possible from standard latest obs workflow to get the top 2 obs inside a mouseover.  Current status?  Fugly but functional.

<img width="352" height="265" alt="image" src="https://github.com/user-attachments/assets/57d1ca13-a965-43cc-b88b-520803b78103" />

**Updated Station Hover Popup Spec**
- Background color: Black
- Text color: White
- Include top 2 conditions
- Include last updated date and time
- Text: ‘Paragraph Bold’ for station name; ’Caption Bold’ for data title; ’Caption’ for data units + Last Updated
