### PR TITLE
Feature some inline style removal

### DIFF
--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -44,13 +44,11 @@ export default function Layout({
   return (
     <React.Fragment>
       <Row>
-        <Col xs={{ span: "12", order: "2" }} md={{ span: "6", order: "2" }}>
-          <div ref={ref} style={{ marginBottom: ".5rem" }}>
-            {sidebar}
-          </div>
+        <Col xs={12} md={6} className="order-2">
+          <div ref={ref}>{sidebar}</div>
         </Col>
 
-        <Col xs={{ span: "12", order: `${isPlatformView ? "2" : "1"}` }} md={{ span: "6", order: "1" }}>
+        <Col xs={12} md={6}>
           <ErddapMap height={params.regionId ? "80vh" : height} {...(isPlatformView && { platformId })} />
           {belowMap ?? <React.Fragment>{belowMap}</React.Fragment>}
         </Col>

--- a/app/(waterLevel)/water-level/page.tsx
+++ b/app/(waterLevel)/water-level/page.tsx
@@ -19,7 +19,7 @@ export default function WaterLevelIndexPage() {
     waterLevelPlatforms &&
     regionList.map((r, index) => {
       return (
-        <Card className="mb-4" key={`sensor-region-list-#${index}`}>
+        <Card className="mb-5" key={`sensor-region-list-#${index}`}>
           <Card.Header>{r.name}</Card.Header>
           <ErddapWaterLevelSensorListBase platforms={waterLevelPlatforms} boundingBox={r.bbox} />
         </Card>

--- a/app/(waterLevel)/water-level/page.tsx
+++ b/app/(waterLevel)/water-level/page.tsx
@@ -19,7 +19,7 @@ export default function WaterLevelIndexPage() {
     waterLevelPlatforms &&
     regionList.map((r, index) => {
       return (
-        <Card style={{ marginBottom: "20px" }} key={`sensor-region-list-#${index}`}>
+        <Card className="mb-4" key={`sensor-region-list-#${index}`}>
           <Card.Header>{r.name}</Card.Header>
           <ErddapWaterLevelSensorListBase platforms={waterLevelPlatforms} boundingBox={r.bbox} />
         </Card>
@@ -29,10 +29,10 @@ export default function WaterLevelIndexPage() {
   return (
     <>
       <Row>
-        <Col sm={{ order: "2" }} md={{ order: "1", span: "6" }}>
+        <Col xs={12} md={6}>
           {waterLevelPlatforms && <ErddapWaterLevelMapBase platforms={waterLevelPlatforms} height={"60vh"} />}
         </Col>
-        <Col sm={{ order: "1" }} md={{ order: "2", span: "6" }}>
+        <Col xs={12} md={6}>
           {regionCards}
         </Col>
       </Row>

--- a/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
@@ -48,7 +48,7 @@ export default function SensorIdPage(props: { params: Promise<{ sensorId: string
   return (
     <div>
       <SecondaryBanner>
-        <p style={{ fontStyle: "italic", fontSize: "14px", marginBottom: "0px", textAlign: "center" }}>
+        <p className="text-center p-0 m-0">
           For official watch, warning, advisory, and forecast information please visit the{" "}
           <a href="https://www.weather.gov/erh/coastalflood" target="_blank">
             NWS Eastern Region Coastal Flood Page

--- a/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
+++ b/app/(waterLevel)/water-level/sensor/[sensorId]/page.tsx
@@ -48,7 +48,7 @@ export default function SensorIdPage(props: { params: Promise<{ sensorId: string
   return (
     <div>
       <SecondaryBanner>
-        <p className="text-center p-0 m-0">
+        <p className="text-center fst-italic p-0 m-0">
           For official watch, warning, advisory, and forecast information please visit the{" "}
           <a href="https://www.weather.gov/erh/coastalflood" target="_blank">
             NWS Eastern Region Coastal Flood Page

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,9 +15,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="App d-flex flex-column min-vh-100">
           <Providers>
             <NavBar />
-            <div className="container-fluid">
-              {children}
-            </div>
+            <div className="container-fluid">{children}</div>
             <Footer />
           </Providers>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,12 +10,12 @@ import "../src/index.scss"
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" style={{ margin: 0, overflow: "none" }}>
+    <html lang="en">
       <body>
-        <div className="App" style={{ position: "relative", minHeight: "100vh" }}>
+        <div className="App d-flex flex-column min-vh-100">
           <Providers>
             <NavBar />
-            <div className="container-fluid" style={{ paddingBottom: "110px" }}>
+            <div className="container-fluid">
               {children}
             </div>
             <Footer />

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts"
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -6,9 +6,7 @@ import Row from "react-bootstrap/Row"
 const colSize = 10
 
 export const Footer: React.FunctionComponent = () => (
-  <div
-    className="mt-auto"
-  >
+  <div className="mt-auto">
     <Row>
       <Col md={colSize} className="mx-auto text-center">
         Copyright © 2021 ~ NERACOOS

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -6,7 +6,7 @@ import Row from "react-bootstrap/Row"
 const colSize = 10
 
 export const Footer: React.FunctionComponent = () => (
-  <footer className="footer mt-4 pb-2 footer-font">
+  <footer className="footer mt-auto pb-2 footer-font">
     <Row className="p-1 pt-2">
       <Col md={colSize} className="mx-auto text-center">
         Copyright © 2021 ~ NERACOOS

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -3,27 +3,18 @@ import * as React from "react"
 import Col from "react-bootstrap/Col"
 import Row from "react-bootstrap/Row"
 
-const textStyle = { fontSize: ".8rem", padding: ".25rem" }
-
 const colSize = 10
 
 export const Footer: React.FunctionComponent = () => (
   <div
-    className="footer"
-    style={{
-      position: "absolute",
-      bottom: 0,
-      width: "100%",
-      paddingBottom: "10px",
-      height: "110px",
-    }}
+    className="mt-auto"
   >
-    <Row style={{ ...textStyle, paddingTop: "1rem" }}>
+    <Row>
       <Col md={colSize} className="mx-auto text-center">
         Copyright © 2021 ~ NERACOOS
       </Col>
     </Row>
-    <Row style={textStyle}>
+    <Row>
       <Col md={colSize} className="mx-auto text-center">
         Use{" "}
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSdzP90655d-ZuDGpdgcMmTvxW1sgR_Hg4KI1KCfQDFU8MMF0g/viewform?usp=sf_link">
@@ -32,7 +23,7 @@ export const Footer: React.FunctionComponent = () => (
         to send us feedback or bug reports
       </Col>
     </Row>
-    <Row style={textStyle}>
+    <Row>
       <Col md={colSize} className="mx-auto text-center">
         Product of <a href="http://www.neracoos.org/">NERACOOS.org</a> - Developed and maintained by the{" "}
         <a href="https://gmri.org/commitments/science/ocean-data-products/">Gulf of Maine Research Institute</a>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -6,13 +6,13 @@ import Row from "react-bootstrap/Row"
 const colSize = 10
 
 export const Footer: React.FunctionComponent = () => (
-  <div className="mt-auto">
-    <Row>
+  <footer className="footer mt-4 pb-2 footer-font">
+    <Row className="p-1 pt-2">
       <Col md={colSize} className="mx-auto text-center">
         Copyright © 2021 ~ NERACOOS
       </Col>
     </Row>
-    <Row>
+    <Row className="p-1">
       <Col md={colSize} className="mx-auto text-center">
         Use{" "}
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSdzP90655d-ZuDGpdgcMmTvxW1sgR_Hg4KI1KCfQDFU8MMF0g/viewform?usp=sf_link">
@@ -21,13 +21,13 @@ export const Footer: React.FunctionComponent = () => (
         to send us feedback or bug reports
       </Col>
     </Row>
-    <Row>
+    <Row className="p-1">
       <Col md={colSize} className="mx-auto text-center">
         Product of <a href="http://www.neracoos.org/">NERACOOS.org</a> - Developed and maintained by the{" "}
         <a href="https://gmri.org/commitments/science/ocean-data-products/">Gulf of Maine Research Institute</a>
       </Col>
     </Row>
-  </div>
+  </footer>
 )
 
 export default Footer

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -6,7 +6,7 @@ import Row from "react-bootstrap/Row"
 const colSize = 10
 
 export const Footer: React.FunctionComponent = () => (
-  <footer className="footer mt-auto pb-2 footer-font">
+  <footer className="footer mt-auto pb-2 caption">
     <Row className="p-1 pt-2">
       <Col md={colSize} className="mx-auto text-center">
         Copyright © 2021 ~ NERACOOS

--- a/src/components/SecondaryBanner/index.tsx
+++ b/src/components/SecondaryBanner/index.tsx
@@ -2,10 +2,7 @@ import Alert from "react-bootstrap/Alert"
 
 export const SecondaryBanner = ({ children }) => {
   return (
-    <Alert
-      variant="secondary"
-      style={{ padding: "5px", marginRight: "-12px", marginLeft: "-12px", marginTop: "-16px", borderRadius: 0 }}
-    >
+    <Alert variant="secondary" className="secondary-alert d-flex justify-content-center p-1 rounded-0 min-wh-100">
       {children}
     </Alert>
   )

--- a/src/components/SecondaryBanner/index.tsx
+++ b/src/components/SecondaryBanner/index.tsx
@@ -1,9 +1,5 @@
 import Alert from "react-bootstrap/Alert"
 
 export const SecondaryBanner = ({ children }) => {
-  return (
-    <Alert variant="secondary" className="secondary-alert d-flex justify-content-center p-1 rounded-0 min-wh-100">
-      {children}
-    </Alert>
-  )
+  return <Alert className="secondary-alert d-flex justify-content-center p-1 rounded-0 min-wh-100">{children}</Alert>
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -109,6 +109,12 @@ a {
 }
 // ========== TYPOGRAPHY END ==========
 
+.secondary-alert {
+  top: -16px;
+  margin-left: -16px;
+  margin-right: -16px;
+}
+
 .App .alert-primary {
   color: $primary;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -41,6 +41,21 @@ $dig-colors: (
 $font-family-base: "Montserrat", Arial, sans-serif;
 $theme-colors: map-merge($theme-colors, $dig-colors);
 
+$grid-gutter-width: 1.25rem;
+$spacers: (
+  0: 0,
+  1: 0.25rem,
+  2: 0.5rem,
+  3: 0.75rem,
+  4: 1rem,
+  5: 1.25rem,
+  6: 1.5rem,
+  7: 1.75rem,
+  8: 2rem,
+  9: 2.25rem,
+  10: 2.5rem,
+);
+
 @import "../node_modules/bootstrap/scss/bootstrap.scss";
 // @import "~bootstrap/scss/variables";
 // @import "~bootstrap/scss/mixins";
@@ -121,8 +136,9 @@ a {
   font-size: 0.8rem;
 }
 
-.App .alert-primary {
-  color: $primary;
+.alert-primary {
+  background-color: #ced8dc;
+  border-color: #ced8dc;
 }
 
 .App .navbar-brand .nav-link,

--- a/src/index.scss
+++ b/src/index.scss
@@ -113,6 +113,8 @@ a {
   top: -16px;
   margin-left: -16px;
   margin-right: -16px;
+  font-size: 0.875rem;
+  background-color: #d1e7ea;
 }
 
 .footer-font {

--- a/src/index.scss
+++ b/src/index.scss
@@ -115,6 +115,10 @@ a {
   margin-right: -16px;
 }
 
+.footer-font {
+  font-size: 0.8rem;
+}
+
 .App .alert-primary {
   color: $primary;
 }

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`Storybook Snapshot Tests > Components/Alerts/Warning > Warning 1`] = `
 exports[`Storybook Snapshot Tests > Components/Footer > footer 1`] = `
 <div>
   <footer
-    class="footer mt-auto pb-2 footer-font"
+    class="footer mt-auto pb-2 caption"
   >
     <div
       class="p-1 pt-2 row"

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -50,13 +50,11 @@ exports[`Storybook Snapshot Tests > Components/Alerts/Warning > Warning 1`] = `
 
 exports[`Storybook Snapshot Tests > Components/Footer > footer 1`] = `
 <div>
-  <div
-    class="footer"
-    style="position: absolute; bottom: 0px; width: 100%; padding-bottom: 10px; height: 110px;"
+  <footer
+    class="footer mt-4 pb-2 footer-font"
   >
     <div
-      class="row"
-      style="font-size: 0.8rem; padding: 1rem 0.25rem 0.25rem;"
+      class="p-1 pt-2 row"
     >
       <div
         class="mx-auto text-center col-md-10"
@@ -65,8 +63,7 @@ exports[`Storybook Snapshot Tests > Components/Footer > footer 1`] = `
       </div>
     </div>
     <div
-      class="row"
-      style="font-size: 0.8rem; padding: 0.25rem;"
+      class="p-1 row"
     >
       <div
         class="mx-auto text-center col-md-10"
@@ -83,8 +80,7 @@ exports[`Storybook Snapshot Tests > Components/Footer > footer 1`] = `
       </div>
     </div>
     <div
-      class="row"
-      style="font-size: 0.8rem; padding: 0.25rem;"
+      class="p-1 row"
     >
       <div
         class="mx-auto text-center col-md-10"
@@ -104,7 +100,7 @@ exports[`Storybook Snapshot Tests > Components/Footer > footer 1`] = `
         </a>
       </div>
     </div>
-  </div>
+  </footer>
 </div>
 `;
 

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`Storybook Snapshot Tests > Components/Alerts/Warning > Warning 1`] = `
 exports[`Storybook Snapshot Tests > Components/Footer > footer 1`] = `
 <div>
   <footer
-    class="footer mt-4 pb-2 footer-font"
+    class="footer mt-auto pb-2 footer-font"
   >
     <div
       class="p-1 pt-2 row"


### PR DESCRIPTION
@cgalvarino

Intermediate step working towards https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3875 & https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3986

- Converts inline style tags to bootstrap class utilities in files relevant to the eventual goal of standardizing the bootstrap grid.
-  Added a couple custom css selectors to keep things consistent with prod.
- Preemptively added custom spacers in index.scss to match up with the dig rem specifications. Slightly out of scope for this PR but I think it'll save some headache from going back to refit during the next PR

Shouldn't be too much changed visibly at this point. Tried to stick with the original styles as much as possible. Footer does have updated font in keeping with the dig updates.

**Before**
<img width="1440" height="810" alt="Screenshot 2026-03-23 at 3 58 25 PM" src="https://github.com/user-attachments/assets/53b151f3-8625-4829-9cb1-e20187fe3186" />



**After**
<img width="1440" height="810" alt="Screenshot 2026-03-23 at 3 57 00 PM" src="https://github.com/user-attachments/assets/af5565cc-eee3-415d-bcb1-35d1b712783e" />

