### PR TITLE
Prev/Next region navigation -- styled

### DIFF
--- a/app/(platformMap)/@sidebar/region/[regionId]/page.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/page.tsx
@@ -20,11 +20,11 @@ export default function RegionSidebar(props: { params: Promise<{ regionId: strin
   return (
     <div>
       <h2>Platforms in {region.name}</h2>
-      <div className="row mb-2">
-        <div className="col-6">
+      <div className="row mb-2 align-items-center">
+        <div className="d-flex col-6">
           <NextRegion region={region} offset={-1} />
         </div>
-        <div className="col-6 text-end">
+        <div className="d-flex col-6 justify-content-end">
           <NextRegion region={region} offset={1} />
         </div>
       </div>

--- a/app/(platformMap)/@sidebar/region/[regionId]/page.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/page.tsx
@@ -4,7 +4,7 @@ import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
 import { regionList } from "Shared/constants"
 import { Region } from "Shared/regions"
 
-import { RegionList } from "./region"
+import { RegionList, NextRegion } from "./region"
 import { useDecodedUrl } from "util/hooks"
 
 export default function RegionSidebar(props: { params: Promise<{ regionId: string }> }) {
@@ -20,6 +20,14 @@ export default function RegionSidebar(props: { params: Promise<{ regionId: strin
   return (
     <div>
       <h2>Platforms in {region.name}</h2>
+      <div className="row mb-2">
+        <div className="col-6">
+          <NextRegion region={region} offset={-1} />
+        </div>
+        <div className="col-6 text-end">
+          <NextRegion region={region} offset={1} />
+        </div>
+      </div>
       <DehydratedPlatforms>
         <RegionList region={region} />
       </DehydratedPlatforms>

--- a/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
@@ -31,9 +31,9 @@ export function NextRegion({ region, offset }: { region: Region; offset: number 
         key={regionList[nextRegionIdx].name}
         className="d-flex flex-row align-items-center gap-1"
       >
-        {offset < 0 && <ArrowLeftIcon height={14} className="" />}
+        {offset < 0 && <ArrowLeftIcon height={14} className="text-primary" />}
         <span className="text-center">{regionList[nextRegionIdx].name}</span>
-        {offset > 0 && <ArrowRightIcon height={14} className="" />}
+        {offset > 0 && <ArrowRightIcon height={14} className="text-primary" />}
       </Link>
     </>
   )

--- a/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
@@ -31,9 +31,9 @@ export function NextRegion({ region, offset }: { region: Region; offset: number 
         key={regionList[nextRegionIdx].name}
         className="d-flex flex-row align-items-center gap-1"
       >
-        {offset < 0 && <ArrowLeftIcon height={14} className="text-primary" />}
+        {offset < 0 && <ArrowLeftIcon className="text-primary fa-sm" />}
         <span className="text-center">{regionList[nextRegionIdx].name}</span>
-        {offset > 0 && <ArrowRightIcon height={14} className="text-primary" />}
+        {offset > 0 && <ArrowRightIcon className="text-primary fa-sm" />}
       </Link>
     </>
   )

--- a/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
@@ -3,6 +3,7 @@ import { ErddapPlatformList } from "Features/ERDDAP"
 import { Region, regionList } from "Shared/regions"
 import { paths } from "Shared/constants"
 import { urlPartReplacer } from "Shared/urlParams"
+import { ArrowLeftIcon, ArrowRightIcon } from "Shared/icons/iconsMap"
 
 import Link from "next/link"
 
@@ -24,13 +25,16 @@ export function NextRegion({ region, offset }: { region: Region; offset: number 
   }
 
   return (
-    <div>
+    <>
       <Link
         href={urlPartReplacer(paths.regions.region, ":id", regionList[nextRegionIdx].slug as string)}
         key={regionList[nextRegionIdx].name}
+        className="d-flex flex-row align-items-center gap-1"
       >
-        {regionList[nextRegionIdx].name}
+        {offset < 0 && <ArrowLeftIcon height={14} className="" />}
+        <span className="text-center">{regionList[nextRegionIdx].name}</span>
+        {offset > 0 && <ArrowRightIcon height={14} className="" />}
       </Link>
-    </div>
+    </>
   )
 }

--- a/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
@@ -31,9 +31,9 @@ export function NextRegion({ region, offset }: { region: Region; offset: number 
         key={regionList[nextRegionIdx].name}
         className="d-flex flex-row align-items-center gap-1"
       >
-        {offset < 0 && <ArrowLeftIcon className="text-primary fa-sm" />}
+        {offset < 0 && <ArrowLeftIcon className="text-primary fa-md" />}
         <span className="text-center">{regionList[nextRegionIdx].name}</span>
-        {offset > 0 && <ArrowRightIcon className="text-primary fa-sm" />}
+        {offset > 0 && <ArrowRightIcon className="text-primary fa-md" />}
       </Link>
     </>
   )

--- a/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/region.tsx
@@ -1,7 +1,36 @@
 "use client"
 import { ErddapPlatformList } from "Features/ERDDAP"
-import { Region } from "Shared/regions"
+import { Region, regionList } from "Shared/regions"
+import { paths } from "Shared/constants"
+import { urlPartReplacer } from "Shared/urlParams"
+
+import Link from "next/link"
 
 export function RegionList({ region }: { region: Region }) {
   return <ErddapPlatformList boundingBox={region.bbox} />
+}
+
+export function NextRegion({ region, offset }: { region: Region; offset: number }) {
+  let regionIdx = regionList.findIndex((r) => r.slug === region.slug)
+  if (regionIdx < 0) {
+    return <div />
+  }
+
+  let nextRegionIdx = (regionIdx + regionList.length + offset) % regionList.length
+  let prevRegionIdx = (regionIdx + regionList.length - 1) % regionList.length
+  // Don't show if we only have 1 region or we're trying to show next and it's the same as prev.
+  if (regionIdx == nextRegionIdx || (offset == 1 && nextRegionIdx == prevRegionIdx)) {
+    return <div />
+  }
+
+  return (
+    <div>
+      <Link
+        href={urlPartReplacer(paths.regions.region, ":id", regionList[nextRegionIdx].slug as string)}
+        key={regionList[nextRegionIdx].name}
+      >
+        {regionList[nextRegionIdx].name}
+      </Link>
+    </div>
+  )
 }

--- a/src/Shared/icons/iconComponent.tsx
+++ b/src/Shared/icons/iconComponent.tsx
@@ -11,8 +11,8 @@ type IconProps = {
 }
 
 function mkIcon(faIcon: IconDefinition) {
-  function Icon({ className, height, ...rest }: IconProps) {
-    return <FontAwesomeIcon icon={faIcon} className={className} height={height} {...rest} />
+  function Icon({ className, ...rest }: IconProps) {
+    return <FontAwesomeIcon icon={faIcon} className={className} {...rest} />
   }
   return Icon
 }

--- a/src/Shared/icons/iconComponent.tsx
+++ b/src/Shared/icons/iconComponent.tsx
@@ -7,11 +7,12 @@ import { IconDefinition } from "@fortawesome/fontawesome-svg-core"
 
 type IconProps = {
   className?: string
+  height?: number
 }
 
 function mkIcon(faIcon: IconDefinition) {
-  function Icon({ className, ...props }: IconProps) {
-    return <FontAwesomeIcon icon={faIcon} className={className} {...props} />
+  function Icon({ className, height, ...rest }: IconProps) {
+    return <FontAwesomeIcon icon={faIcon} className={className} height={height} {...rest} />
   }
   return Icon
 }


### PR DESCRIPTION
@cgalvarino 

A new branch based off of #4022 aiming to get to #3879.

Adds arrow icons and responsive text. Cape Cod / Buzzard's Bay has some tricky formatting. Went through several complicated solutions before deciding that centering the text is the happiest medium I could find at the moment.

**Before**
<img width="721" height="406" alt="Screenshot 2026-03-31 at 4 39 51 PM" src="https://github.com/user-attachments/assets/7fe866d6-5965-43e3-b7bf-336b6f6bd1a3" />

**After**
<img width="354" height="93" alt="Screenshot 2026-03-31 at 4 40 45 PM" src="https://github.com/user-attachments/assets/843eae68-470b-42ae-adeb-17977dd01bc7" />

<img width="155" height="100" alt="Screenshot 2026-03-31 at 4 41 12 PM" src="https://github.com/user-attachments/assets/0d1ead6f-a277-48b1-8d69-44ad82ee785b" />
