### PR TITLE
Modified display unit default

### DIFF
--- a/src/Features/Units/Converter/conversions.ts
+++ b/src/Features/Units/Converter/conversions.ts
@@ -27,6 +27,8 @@ export class DataTypeConversion {
    * @param english_unit Unit type that convert-units understands as output
    * @param metric_unit_display Friendly unit name
    * @param english_unit_display Friendly unit name
+   * @param metric_unit_abbreviation_display Friendly abbreviation
+   * @param english_unit_abbreviation_display Friendly abbreviation
    */
   constructor(
     public data_type: string,
@@ -36,6 +38,8 @@ export class DataTypeConversion {
     protected english_unit: string,
     protected metric_unit_display?: string,
     protected english_unit_display?: string,
+    protected metric_unit_abbreviation_display?: string,
+    protected english_unit_abbreviation_display?: string,
   ) {}
 
   /**
@@ -82,15 +86,19 @@ export class DataTypeConversion {
   }
 
   /**
-   * Return the display name for the given unit system
+   * Return the abbreviated display name for the given unit system
    * @param unitSystem Unit system that the name should be displayed for
    */
   public displayName(unitSystem: UnitSystem): string {
     switch (unitSystem) {
       case UnitSystem.metric:
-        return this.metric_unit_display ? this.metric_unit_display : this.metric_unit
+        return this.metric_unit_abbreviation_display
+          ? this.metric_unit_abbreviation_display
+          : this.displayFullUnitName(unitSystem)
       default:
-        return this.english_unit_display ? this.english_unit_display : this.english_unit
+        return this.english_unit_abbreviation_display
+          ? this.english_unit_abbreviation_display
+          : this.displayFullUnitName(unitSystem)
     }
   }
 
@@ -100,6 +108,19 @@ export class DataTypeConversion {
         return this.metric_unit
       default:
         return this.english_unit
+    }
+  }
+
+  /**
+   * Return full unit display name.
+   * @param unitSystem
+   */
+  public displayFullUnitName(unitSystem: UnitSystem): string {
+    switch (unitSystem) {
+      case UnitSystem.metric:
+        return this.metric_unit_display ? this.metric_unit_display : this.metric_unit
+      default:
+        return this.english_unit_display ? this.english_unit_display : this.english_unit
     }
   }
 }


### PR DESCRIPTION
@cgalvarino @abkfenris 

Groundwork infrastructure to begin working on #3875 "Abbreviate units everywhere". Chatting with Alex, the preferred move here is to keep the ability to display long unit names rather than a straight replacement. 

Instead of building a new abbreviation function and trying to make the change from displayName across the entire codebase, I just changed the functionality to display the abbreviated unit with a fallback to the original choice if unavailable. Made a small getter function displayFullUnitName to allow us to directly snag that long name in a future tooltip component.