### PR TITLE
Top 2 observations in map hover

### DIFF
--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -17,6 +17,7 @@ import { paths } from "Shared/constants"
 import { BoundingBox, InitialRegion, regionList } from "Shared/regions"
 import { EsriOceanBasemapLayer, EsriOceanReferenceLayer } from "components/Map"
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { PlatformInfoLite } from "components/PlatformInfo/platformInfo"
 
 import { aDayAgoRounded, formatDate, threeDaysAgoRounded, weeksInFuture } from "Shared/time"
 import { urlPartReplacer } from "Shared/urlParams"
@@ -122,7 +123,7 @@ export const PlatformLayer = ({ platform, selected, old = false }: PlatformLayer
               [router, url],
             )}
           >
-            {platformName(platform)}
+            <PlatformInfoLite id={platform.id} />
           </Button>
         </RPopup>
       </RFeature>

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -46,10 +46,8 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
 
 export const ErddapPlatformInfoLite: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
   return (
-    <Card role="complementary">
-      <Card.Body>
-        <Card.Title role="header">Station {platformName(platform)}</Card.Title>
-      </Card.Body>
-    </Card>
+    <React.Fragment>
+      Station {platformName(platform)}
+    </React.Fragment>
   )
 }

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -43,3 +43,13 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
     </Card>
   )
 }
+
+export const ErddapPlatformInfoLite: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
+  return (
+    <Card role="complementary">
+      <Card.Body>
+        <Card.Title role="header">Station {platformName(platform)}</Card.Title>
+      </Card.Body>
+    </Card>
+  )
+}

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -46,8 +46,8 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
 
 export const ErddapPlatformInfoLite: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
   return (
-    <React.Fragment>
-      Station {platformName(platform)}
-    </React.Fragment>
+    <p className="m-0">
+      <strong>Station {platformName(platform)}</strong>
+    </p>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -22,7 +22,6 @@ interface TableItemProps {
   platform: PlatformFeature
   timeSeries: PlatformTimeSeries
   unitSystem: UnitSystem
-  useShortNameThreshold?: number
 }
 
 type TableItemDisplayProps = Pick<TableItemProps, "timeSeries" | "unitSystem"> &
@@ -48,14 +47,10 @@ const TableItemDisplay: React.FC<TableItemDisplayProps> = ({
   )
 }
 
-export const TableItem = ({ timeSeries, unitSystem, platform, useShortNameThreshold }: TableItemProps) => {
+export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) => {
   const tooltipId = `${timeSeries.data_type.standard_name}-tooltip`
 
   let name = timeSeries.data_type.long_name
-  if (typeof useShortNameThreshold !== 'undefined') {
-    name = (name.length > useShortNameThreshold ? timeSeries.data_type.short_name : name) || name;
-  }
-
   if (timeSeries.depth && timeSeries.depth > 0) {
     name = `${name} @ ${timeSeries.depth}m`
   }
@@ -89,5 +84,31 @@ export const TableItem = ({ timeSeries, unitSystem, platform, useShortNameThresh
         </span>
       </OverlayTrigger>
     </Link>
+  )
+}
+
+/**
+ *  Render observation items in a format acceptable for the map hover.
+ */
+export const MapItemPopup = ({ timeSeries, unitSystem }: TableItemProps) => {
+  const shortNameThreshold: number = 50
+  let name =
+    timeSeries.data_type.long_name.length > shortNameThreshold
+      ? timeSeries.data_type.short_name
+      : timeSeries.data_type.long_name
+
+  if (timeSeries.depth && timeSeries.depth > 0) {
+    name = `${name} @ ${timeSeries.depth}m`
+  }
+
+  const unit_converter = converter(timeSeries.data_type.standard_name)
+  const value = unit_converter.convertTo(timeSeries.value as number, unitSystem)
+
+  return (
+    <div className="caption d-flex flex-row gap-1">
+      <strong>{name}:</strong>
+      <span>{typeof value === "number" ? round(value as number, 1) : value}</span>
+      <span>{unit_converter.displayName(unitSystem)}</span>
+    </div>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.tsx
@@ -22,6 +22,7 @@ interface TableItemProps {
   platform: PlatformFeature
   timeSeries: PlatformTimeSeries
   unitSystem: UnitSystem
+  useShortNameThreshold?: number
 }
 
 type TableItemDisplayProps = Pick<TableItemProps, "timeSeries" | "unitSystem"> &
@@ -47,10 +48,14 @@ const TableItemDisplay: React.FC<TableItemDisplayProps> = ({
   )
 }
 
-export const TableItem = ({ timeSeries, unitSystem, platform }: TableItemProps) => {
+export const TableItem = ({ timeSeries, unitSystem, platform, useShortNameThreshold }: TableItemProps) => {
   const tooltipId = `${timeSeries.data_type.standard_name}-tooltip`
 
   let name = timeSeries.data_type.long_name
+  if (typeof useShortNameThreshold !== 'undefined') {
+    name = (name.length > useShortNameThreshold ? timeSeries.data_type.short_name : name) || name;
+  }
+
   if (timeSeries.depth && timeSeries.depth > 0) {
     name = `${name} @ ${timeSeries.depth}m`
   }

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -9,8 +9,9 @@ import { UnitSystem } from "Features/Units/types"
 import { UsePlatformRenderProps } from "../../../hooks/BuoyBarnComponents"
 import { currentConditionsTimeseries } from "../../../utils/currentConditionsTimeseries"
 
-import { itemStyle, TableItem } from "./item"
+import { itemStyle, TableItem, MapItemPopup } from "./item"
 import { platformName } from "Features/ERDDAP/utils/platformName"
+import { PlatformTimeSeries } from "Features/ERDDAP/types"
 
 interface Props extends UsePlatformRenderProps {
   unitSelector?: React.ReactNode
@@ -18,7 +19,18 @@ interface Props extends UsePlatformRenderProps {
   laterThan: Date
   limit?: number
   children?: any
-  useShortNameThreshold?: number
+}
+
+interface LimitedObsProps extends Omit<Props, "laterThan"> {
+  allCurrentConditions: PlatformTimeSeries[]
+  times: Date[]
+}
+
+interface LastUpdatedProps {
+  label: string
+  times: Date[]
+  className?: string
+  boldKey?: boolean
 }
 
 /**
@@ -32,33 +44,31 @@ export const ErddapObservationTable: React.FC<Props> = ({
   laterThan,
   limit,
   children,
-  useShortNameThreshold,
 }: Props) => {
   let { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, laterThan)
-  if (typeof limit !== "undefined") {
-    allCurrentConditionsTimeseries = allCurrentConditionsTimeseries.slice(0, limit)
-  }
+
   const times = allCurrentConditionsTimeseries.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
   times.sort((a, b) => a.valueOf() - b.valueOf())
 
+  if (typeof limit !== "undefined") {
+    return (
+      <LimitedItems
+        allCurrentConditions={allCurrentConditionsTimeseries}
+        limit={limit}
+        unitSystem={unitSystem}
+        platform={platform}
+        times={times}
+      />
+    )
+  }
+
   return (
-    <ListGroup style={{ paddingTop: "1rem" }} as="ul">
-      {times.length > 0 ? (
-        <ListGroup.Item style={itemStyle} as="li">
-          <b>Last updated at:</b>{" "}
-          {times[times.length - 1].toLocaleString(undefined, {
-            hour: "2-digit",
-            hour12: true,
-            minute: "2-digit",
-            month: "short",
-            day: "numeric",
-          })}
-        </ListGroup.Item>
-      ) : (
-        <ListGroup.Item style={itemStyle}>There is no recent data from {platformName(platform)}</ListGroup.Item>
-      )}
+    <ListGroup className="pt-4" as="ul">
+      <ListGroup.Item as="li">
+        <LastUpdated label="Last updated at: " times={times} boldKey />
+      </ListGroup.Item>
       {allCurrentConditionsTimeseries.map((timeSeries, index) => {
-        return <TableItem key={index} timeSeries={timeSeries} platform={platform} unitSystem={unitSystem} useShortNameThreshold={useShortNameThreshold}/>
+        return <TableItem key={index} timeSeries={timeSeries} platform={platform} unitSystem={unitSystem} />
       })}
 
       {unitSelector ? (
@@ -68,5 +78,48 @@ export const ErddapObservationTable: React.FC<Props> = ({
       ) : null}
       {children && <ListGroup.Item>{children}</ListGroup.Item>}
     </ListGroup>
+  )
+}
+
+/**
+ * Render a lightweight limited number of observations.
+ */
+export const LimitedItems: React.FC<LimitedObsProps> = ({
+  allCurrentConditions,
+  limit,
+  unitSystem,
+  platform,
+  times,
+}: LimitedObsProps) => {
+  allCurrentConditions = allCurrentConditions.slice(0, limit)
+  return (
+    <div>
+      <LastUpdated label="Updated: " times={times} className="caption d-flex justify-content-start" />
+      {allCurrentConditions.map((timeSeries, index) => (
+        <MapItemPopup key={index} timeSeries={timeSeries} unitSystem={unitSystem} platform={platform} />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Render a key followed by the last time in a series of dates.
+ */
+const LastUpdated = ({ label, times, className, boldKey }: LastUpdatedProps) => {
+  if (times.length <= 0) return null
+
+  const timeVal = times[times.length - 1].toLocaleString(undefined, {
+    hour: "2-digit",
+    hour12: true,
+    minute: "2-digit",
+    month: "short",
+    day: "numeric",
+  })
+
+  return (
+    <span className={className}>
+      {boldKey ? <strong>{label}</strong> : label}
+      {timeVal}
+    </span>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -13,6 +13,18 @@ import { itemStyle, TableItem, MapItemPopup } from "./item"
 import { platformName } from "Features/ERDDAP/utils/platformName"
 import { PlatformTimeSeries } from "Features/ERDDAP/types"
 
+interface LastUpdatedProps {
+  label: string
+  times: Date[]
+  className?: string
+  boldKey?: boolean
+}
+
+interface LimitedObsProps extends Omit<Props, "laterThan"> {
+  allCurrentConditions: PlatformTimeSeries[]
+  times: Date[]
+}
+
 interface Props extends UsePlatformRenderProps {
   unitSelector?: React.ReactNode
   unitSystem: UnitSystem
@@ -21,16 +33,49 @@ interface Props extends UsePlatformRenderProps {
   children?: any
 }
 
-interface LimitedObsProps extends Omit<Props, "laterThan"> {
-  allCurrentConditions: PlatformTimeSeries[]
-  times: Date[]
+/**
+ * Render a key followed by the last time in a series of dates.
+ */
+const LastUpdated = ({ label, times, className, boldKey }: LastUpdatedProps) => {
+  if (times.length <= 0) {
+    return null
+  }
+
+  const timeVal = times[times.length - 1].toLocaleString(undefined, {
+    hour: "2-digit",
+    hour12: true,
+    minute: "2-digit",
+    month: "short",
+    day: "numeric",
+  })
+
+  return (
+    <span className={className}>
+      {boldKey ? <strong>{label}</strong> : label}
+      {timeVal}
+    </span>
+  )
 }
 
-interface LastUpdatedProps {
-  label: string
-  times: Date[]
-  className?: string
-  boldKey?: boolean
+/**
+ * Render a lightweight limited number of observations.
+ */
+export const LimitedItems: React.FC<LimitedObsProps> = ({
+  allCurrentConditions,
+  limit,
+  unitSystem,
+  platform,
+  times,
+}: LimitedObsProps) => {
+  allCurrentConditions = allCurrentConditions.slice(0, limit)
+  return (
+    <div>
+      <LastUpdated label="Updated: " times={times} className="caption d-flex justify-content-start" />
+      {allCurrentConditions.map((timeSeries, index) => (
+        <MapItemPopup key={index} timeSeries={timeSeries} unitSystem={unitSystem} platform={platform} />
+      ))}
+    </div>
+  )
 }
 
 /**
@@ -78,48 +123,5 @@ export const ErddapObservationTable: React.FC<Props> = ({
       ) : null}
       {children && <ListGroup.Item>{children}</ListGroup.Item>}
     </ListGroup>
-  )
-}
-
-/**
- * Render a lightweight limited number of observations.
- */
-export const LimitedItems: React.FC<LimitedObsProps> = ({
-  allCurrentConditions,
-  limit,
-  unitSystem,
-  platform,
-  times,
-}: LimitedObsProps) => {
-  allCurrentConditions = allCurrentConditions.slice(0, limit)
-  return (
-    <div>
-      <LastUpdated label="Updated: " times={times} className="caption d-flex justify-content-start" />
-      {allCurrentConditions.map((timeSeries, index) => (
-        <MapItemPopup key={index} timeSeries={timeSeries} unitSystem={unitSystem} platform={platform} />
-      ))}
-    </div>
-  )
-}
-
-/**
- * Render a key followed by the last time in a series of dates.
- */
-const LastUpdated = ({ label, times, className, boldKey }: LastUpdatedProps) => {
-  if (times.length <= 0) return null
-
-  const timeVal = times[times.length - 1].toLocaleString(undefined, {
-    hour: "2-digit",
-    hour12: true,
-    minute: "2-digit",
-    month: "short",
-    day: "numeric",
-  })
-
-  return (
-    <span className={className}>
-      {boldKey ? <strong>{label}</strong> : label}
-      {timeVal}
-    </span>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -18,6 +18,7 @@ interface Props extends UsePlatformRenderProps {
   laterThan: Date
   limit?: number
   children?: any
+  useShortNameThreshold?: number
 }
 
 /**
@@ -31,6 +32,7 @@ export const ErddapObservationTable: React.FC<Props> = ({
   laterThan,
   limit,
   children,
+  useShortNameThreshold,
 }: Props) => {
   let { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, laterThan)
   if (typeof limit !== "undefined") {
@@ -56,7 +58,7 @@ export const ErddapObservationTable: React.FC<Props> = ({
         <ListGroup.Item style={itemStyle}>There is no recent data from {platformName(platform)}</ListGroup.Item>
       )}
       {allCurrentConditionsTimeseries.map((timeSeries, index) => {
-        return <TableItem key={index} timeSeries={timeSeries} platform={platform} unitSystem={unitSystem} />
+        return <TableItem key={index} timeSeries={timeSeries} platform={platform} unitSystem={unitSystem} useShortNameThreshold={useShortNameThreshold}/>
       })}
 
       {unitSelector ? (

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.tsx
@@ -16,6 +16,7 @@ interface Props extends UsePlatformRenderProps {
   unitSelector?: React.ReactNode
   unitSystem: UnitSystem
   laterThan: Date
+  limit?: number
   children?: any
 }
 
@@ -28,9 +29,13 @@ export const ErddapObservationTable: React.FC<Props> = ({
   unitSelector,
   unitSystem,
   laterThan,
+  limit,
   children,
 }: Props) => {
-  const { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, laterThan)
+  let { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, laterThan)
+  if (typeof limit !== "undefined") {
+    allCurrentConditionsTimeseries = allCurrentConditionsTimeseries.slice(0, limit)
+  }
   const times = allCurrentConditionsTimeseries.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
   times.sort((a, b) => a.valueOf() - b.valueOf())
 

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -1,5 +1,6 @@
 "use client"
 import React from "react"
+import Card from "react-bootstrap/Card"
 
 import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
 import { ErddapPlatformInfoPanel, ErddapPlatformInfoLite } from "Features/ERDDAP/Platform/Info"
@@ -44,13 +45,16 @@ export const PlatformInfoLite = ({ id }: { id: string }) => {
   return (
     <UsePlatform platformId={id}>
       {({ platform }) => (
-        <React.Fragment>
-          <div>
-            <PlatformAlerts platform={platform} />
-            <ErddapPlatformInfoLite platform={platform} />
-            <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
-          </div>
-        </React.Fragment>
+        <Card role="complementary">
+          <Card.Body>
+            <Card.Title role="header">
+              <ErddapPlatformInfoLite platform={platform} />
+            </Card.Title>
+            <Card.Text>
+              <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
+            </Card.Text>
+          </Card.Body>
+        </Card>
       )}
     </UsePlatform>
   )

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -51,7 +51,7 @@ export const PlatformInfoLite = ({ id }: { id: string }) => {
               <ErddapPlatformInfoLite platform={platform} />
             </Card.Title>
             <Card.Text>
-              <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
+              <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} useShortNameThreshold={50}/>
             </Card.Text>
           </Card.Body>
         </Card>

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -2,7 +2,7 @@
 import React from "react"
 
 import { PlatformAlerts } from "Features/ERDDAP/Platform/Alerts"
-import { ErddapPlatformInfoPanel } from "Features/ERDDAP/Platform/Info"
+import { ErddapPlatformInfoPanel, ErddapPlatformInfoLite } from "Features/ERDDAP/Platform/Info"
 import { ErddapObservationTable } from "Features/ERDDAP/Platform/Observations/Table/table"
 import { UsePlatform } from "Features/ERDDAP/hooks/BuoyBarnComponents"
 
@@ -28,6 +28,28 @@ export const PlatformInfo = ({ id }: { id: string }) => {
             unitSystem={unitSystem}
             laterThan={aDayAgo}
           />
+        </React.Fragment>
+      )}
+    </UsePlatform>
+  )
+}
+
+/**
+ * A lightweight version of the platform info panel and w/ only a max # of obs.
+ */
+export const PlatformInfoLite = ({ id }: { id: string }) => {
+  const unitSystem = useUnitSystem()
+  const aDayAgo = aDayAgoRounded()
+
+  return (
+    <UsePlatform platformId={id}>
+      {({ platform }) => (
+        <React.Fragment>
+          <div>
+            <PlatformAlerts platform={platform} />
+            <ErddapPlatformInfoLite platform={platform} />
+            <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
+          </div>
         </React.Fragment>
       )}
     </UsePlatform>

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -45,16 +45,10 @@ export const PlatformInfoLite = ({ id }: { id: string }) => {
   return (
     <UsePlatform platformId={id}>
       {({ platform }) => (
-        <Card role="complementary">
-          <Card.Body>
-            <Card.Title role="header">
-              <ErddapPlatformInfoLite platform={platform} />
-            </Card.Title>
-            <Card.Text>
-              <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} useShortNameThreshold={50}/>
-            </Card.Text>
-          </Card.Body>
-        </Card>
+        <div className="d-flex flex-column justify-content-start">
+          <ErddapPlatformInfoLite platform={platform} />
+          <ErddapObservationTable platform={platform} unitSystem={unitSystem} laterThan={aDayAgo} limit={2} />
+        </div>
       )}
     </UsePlatform>
   )


### PR DESCRIPTION
@cgalvarino @abkfenris 

Addresses: #3876
**Updated Station Hover Popup**
- Background color: Black
- Text color: White
- Include top 2 conditions
- Include last updated date and time
- Text: ‘Paragraph Bold’ for station name; ’Caption Bold’ for data title; ’Caption’ for data units + Last Updated

Building off of Charlton's PR: https://github.com/gulfofmaine/Neracoos-1-Buoy-App/pull/4028

**Picked up at**
<img width="1234" height="516" alt="Screenshot 2026-04-08 at 12 13 46 PM" src="https://github.com/user-attachments/assets/7e9b6db0-5cad-4e2c-8ed3-c4d851e6690b" />

**After**
<img width="1363" height="516" alt="Screenshot 2026-04-08 at 12 11 19 PM" src="https://github.com/user-attachments/assets/62ae69ff-3001-492b-bb37-0644f44f1315" />

Messed around for a while trying to get the styling correct with the original approach and found that the coupling to the sidebar table was too tight. Changes to the map hover --> changes to the sidebar

**Notes:**
- Added two components: `MapItemPopup` and `LimitedItems`
- Pulled "last updated" logic out into its own helper for readability: `LastUpdated` 
- Moved the short name threshold into `MapItemPopup`
- Reduced BS card complexity in TSX

Suggestions on this approach? I tried to strike a happy medium between keeping the overarching OBS workflow and allowing the map hover to be its own quite different UI component.