### PR TITLE
Updates to sidebar content on landing

### DIFF
--- a/app/(platformMap)/@sidebar/page.tsx
+++ b/app/(platformMap)/@sidebar/page.tsx
@@ -1,5 +1,5 @@
 import { WagtailBlock } from "Features/WagtailApi/WagtailBlock"
 
 export default function HomeSidebar() {
-  return <WagtailBlock pageId="4" />
+  return <WagtailBlock pageId="19" />
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts"
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/Features/ERDDAP/Superlatives/index.tsx
+++ b/src/Features/ERDDAP/Superlatives/index.tsx
@@ -107,7 +107,7 @@ export const ShowSuperlatives: React.FunctionComponent<ShowSuperlativesProps> = 
   }, [platforms, searchStartTime])
   return (
     <Card className="mt-5">
-      <Card.Header className="d-flex flex-row align-items-center superlative-header">
+      <Card.Header className="d-flex flex-row align-items-center bg-black bg-opacity-5">
         <h3 className="d-flex m-0">Top Wind & Waves - All Regions</h3>
       </Card.Header>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -21,24 +17,12 @@
     "jsx": "react-jsx",
     "baseUrl": "src",
     "paths": {
-      "Shared/*": [
-        "Shared/*"
-      ],
-      "components/*": [
-        "components/*"
-      ],
-      "Pages/*": [
-        "formerly_pages/*"
-      ],
-      "Features/*": [
-        "Features/*"
-      ],
-      "stories/*": [
-        "stories/*"
-      ],
-      "queryClient": [
-        "queryClient"
-      ]
+      "Shared/*": ["Shared/*"],
+      "components/*": ["components/*"],
+      "Pages/*": ["formerly_pages/*"],
+      "Features/*": ["Features/*"],
+      "stories/*": ["stories/*"],
+      "queryClient": ["queryClient"]
     },
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,
@@ -49,15 +33,6 @@
       }
     ]
   },
-  "include": [
-    "src",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "src/setupTests.ts",
-    "**/*.spec.*",
-    "**/*.stories.*",
-    "node_modules"
-  ]
+  "include": ["src", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["src/setupTests.ts", "**/*.spec.*", "**/*.stories.*", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -9,7 +13,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noImplicitAny": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -17,12 +21,24 @@
     "jsx": "react-jsx",
     "baseUrl": "src",
     "paths": {
-      "Shared/*": ["Shared/*"],
-      "components/*": ["components/*"],
-      "Pages/*": ["formerly_pages/*"],
-      "Features/*": ["Features/*"],
-      "stories/*": ["stories/*"],
-      "queryClient": ["queryClient"]
+      "Shared/*": [
+        "Shared/*"
+      ],
+      "components/*": [
+        "components/*"
+      ],
+      "Pages/*": [
+        "formerly_pages/*"
+      ],
+      "Features/*": [
+        "Features/*"
+      ],
+      "stories/*": [
+        "stories/*"
+      ],
+      "queryClient": [
+        "queryClient"
+      ]
     },
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,
@@ -33,6 +49,15 @@
       }
     ]
   },
-  "include": ["src", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
-  "exclude": ["src/setupTests.ts", "**/*.spec.*", "**/*.stories.*", "node_modules"]
+  "include": [
+    "src",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "src/setupTests.ts",
+    "**/*.spec.*",
+    "**/*.stories.*",
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
@cgalvarino 
#3876 

Updates the text content and card color for "How to Use the Dashboard" on the landing page sidebar. 

Notes:
- No specification on the color of the card header? Body is black-5 and the wireframe just looks a hair darker. Currently set to black-10
- No specification on size heading to choose for NERACOOS Mariners' Dashboard. Set to h1 for now.

Spec:
**Get Started**
Renamed title to ‘How to Use Dashboard’ (H3)
Background color: Black 5
Title & Paragraph color: Black
Bullets: ‘Paragraph
Updated Copy

**Before**
<img width="694" height="431" alt="Screenshot 2026-04-10 at 11 42 21 AM" src="https://github.com/user-attachments/assets/7412771a-cd50-4a05-9611-ddcfe586017b" />

**After**
<img width="690" height="409" alt="Screenshot 2026-04-10 at 11 41 00 AM" src="https://github.com/user-attachments/assets/d2c9d6c7-208b-47cf-a2be-0dfaec389352" />

**Eventual Goal**
<img width="645" height="556" alt="Screenshot 2026-04-10 at 11 41 40 AM" src="https://github.com/user-attachments/assets/db7649d6-23b2-430c-a89c-9e1b1c94ff55" />

