### PR TITLE
Wave height unit abbreviation

### DIFF
--- a/src/Features/Units/Converter/data_types/_wave_height.ts
+++ b/src/Features/Units/Converter/data_types/_wave_height.ts
@@ -14,6 +14,6 @@ export class WaveHeight extends DataTypeConversion {
     public data_type: string,
     public display_name: string,
   ) {
-    super(data_type, display_name, "m", "m", "ft", "Meters", "ft")
+    super(data_type, display_name, "m", "m", "ft", "Meters", "ft", "m", "ft")
   }
 }

--- a/src/Features/Units/Converter/data_types/maximum_wave_height.spec.ts
+++ b/src/Features/Units/Converter/data_types/maximum_wave_height.spec.ts
@@ -20,6 +20,6 @@ describe("max_wave_height conversions", () => {
 
   it("display names", () => {
     expect(max_wave_height.displayName(UnitSystem.english)).toBe("ft")
-    expect(max_wave_height.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(max_wave_height.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/predicted_sea_water_level.spec.ts
+++ b/src/Features/Units/Converter/data_types/predicted_sea_water_level.spec.ts
@@ -20,6 +20,6 @@ describe("predicted_sea_water_level conversions", () => {
 
   it("display names", () => {
     expect(predicted_sea_water_level.displayName(UnitSystem.english)).toBe("ft")
-    expect(predicted_sea_water_level.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(predicted_sea_water_level.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/sea_surface_wave_significant_height.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_surface_wave_significant_height.spec.ts
@@ -20,6 +20,6 @@ describe("sea_surface_wave_significant_height conversions", () => {
 
   it("display names", () => {
     expect(sea_surface_wave_significant_height.displayName(UnitSystem.english)).toBe("ft")
-    expect(sea_surface_wave_significant_height.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(sea_surface_wave_significant_height.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/sea_water_level.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_water_level.spec.ts
@@ -20,6 +20,6 @@ describe("sea_water_level conversions", () => {
 
   it("display names", () => {
     expect(sea_water_level.displayName(UnitSystem.english)).toBe("ft")
-    expect(sea_water_level.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(sea_water_level.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves.spec.ts
+++ b/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves.spec.ts
@@ -20,6 +20,6 @@ describe("significant_height_of_wind_and_swell_waves conversions", () => {
 
   it("display names", () => {
     expect(significant_height_of_wind_and_swell_waves.displayName(UnitSystem.english)).toBe("ft")
-    expect(significant_height_of_wind_and_swell_waves.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(significant_height_of_wind_and_swell_waves.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves_3.spec.ts
+++ b/src/Features/Units/Converter/data_types/significant_height_of_wind_and_swell_waves_3.spec.ts
@@ -20,6 +20,6 @@ describe("significant_height_of_wind_and_swell_waves_3 conversions", () => {
 
   it("display names", () => {
     expect(significant_height_of_wind_and_swell_waves_3.displayName(UnitSystem.english)).toBe("ft")
-    expect(significant_height_of_wind_and_swell_waves_3.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(significant_height_of_wind_and_swell_waves_3.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/significant_wave_height.spec.ts
+++ b/src/Features/Units/Converter/data_types/significant_wave_height.spec.ts
@@ -20,6 +20,6 @@ describe("significant_wave_height conversions", () => {
 
   it("display names", () => {
     expect(significant_wave_height.displayName(UnitSystem.english)).toBe("ft")
-    expect(significant_wave_height.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(significant_wave_height.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/surface_altitude.spec.ts
+++ b/src/Features/Units/Converter/data_types/surface_altitude.spec.ts
@@ -20,6 +20,6 @@ describe("surface_altitude conversions", () => {
 
   it("display names", () => {
     expect(surface_altitude.displayName(UnitSystem.english)).toBe("ft")
-    expect(surface_altitude.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(surface_altitude.displayName(UnitSystem.metric)).toBe("m")
   })
 })


### PR DESCRIPTION
@cgalvarino
https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3875 -- Abbreviate units everywhere

"Meters" --> "m" on wave height observations.
Feet were already represented as "ft".

**Before**
<img width="461" height="594" alt="Screenshot 2026-04-15 at 10 40 27 AM" src="https://github.com/user-attachments/assets/852ea56d-ad6e-4ea0-883e-f8d3a94f5ca3" />


**After**
<img width="461" height="594" alt="Screenshot 2026-04-15 at 10 40 45 AM" src="https://github.com/user-attachments/assets/77edf9d5-c0b2-4e0e-99ac-e5f87954ecd5" />


