### PR TITLE
Visibility units abbreviated

### DIFF
--- a/src/Features/Units/Converter/data_types/_visibility.ts
+++ b/src/Features/Units/Converter/data_types/_visibility.ts
@@ -15,7 +15,7 @@ export class Visibility extends DataTypeConversion {
     public data_type: string,
     public display_name: string,
   ) {
-    super(data_type, display_name, "m", "km", "nMi", "Kilometers", "Nautical Miles")
+    super(data_type, display_name, "m", "km", "nMi", "Kilometers", "Nautical Miles", "km", "nMi")
   }
 
   public convertTo(value: number, unitSystem: UnitSystem): number {

--- a/src/Features/Units/Converter/data_types/max_visibility.spec.ts
+++ b/src/Features/Units/Converter/data_types/max_visibility.spec.ts
@@ -19,7 +19,7 @@ describe("max_visiblity conversions", () => {
   })
 
   it("display names", () => {
-    expect(max_visibility.displayName(UnitSystem.english)).toBe("Nautical Miles")
-    expect(max_visibility.displayName(UnitSystem.metric)).toBe("Kilometers")
+    expect(max_visibility.displayName(UnitSystem.english)).toBe("nMi")
+    expect(max_visibility.displayName(UnitSystem.metric)).toBe("km")
   })
 })

--- a/src/Features/Units/Converter/data_types/min_visibility.spec.ts
+++ b/src/Features/Units/Converter/data_types/min_visibility.spec.ts
@@ -19,7 +19,7 @@ describe("min_visiblity conversions", () => {
   })
 
   it("display names", () => {
-    expect(min_visibility.displayName(UnitSystem.english)).toBe("Nautical Miles")
-    expect(min_visibility.displayName(UnitSystem.metric)).toBe("Kilometers")
+    expect(min_visibility.displayName(UnitSystem.english)).toBe("nMi")
+    expect(min_visibility.displayName(UnitSystem.metric)).toBe("km")
   })
 })

--- a/src/Features/Units/Converter/data_types/visibility_in_air.spec.ts
+++ b/src/Features/Units/Converter/data_types/visibility_in_air.spec.ts
@@ -19,7 +19,7 @@ describe("min_visiblity conversions", () => {
   })
 
   it("display names", () => {
-    expect(visibility_in_air.displayName(UnitSystem.english)).toBe("Nautical Miles")
-    expect(visibility_in_air.displayName(UnitSystem.metric)).toBe("Kilometers")
+    expect(visibility_in_air.displayName(UnitSystem.english)).toBe("nMi")
+    expect(visibility_in_air.displayName(UnitSystem.metric)).toBe("km")
   })
 })


### PR DESCRIPTION
@cgalvarino
https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3875 -- Abbreviate units everywhere

"Nautical Miles" -> "nMi"
"Kilometers" -> "nMi", updated stories

**Note:** I was unable to find a station that was actually reporting visibility, so was unable to manually test these changes. Storybook & Playwright are green.