### PR TITLE
Tidal units abbreviated

### DIFF
--- a/src/Features/Units/Converter/data_types/_tidal_level.ts
+++ b/src/Features/Units/Converter/data_types/_tidal_level.ts
@@ -14,7 +14,7 @@ export class TidalLevel extends DataTypeConversion {
     public data_type: string,
     public display_name: string,
   ) {
-    super(data_type, display_name, "m", "m", "ft", "Meters", "ft")
+    super(data_type, display_name, "m", "m", "ft", "Meters", "ft", "m", "ft")
   }
 }
 

--- a/src/Features/Units/Converter/data_types/sea_surface_height_above_geopotential_datum.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_surface_height_above_geopotential_datum.spec.ts
@@ -20,6 +20,6 @@ describe("sea_surface_height_above_geopotential_datum conversions", () => {
 
   it("display names", () => {
     expect(sea_surface_height_above_geopotential_datum.displayName(UnitSystem.english)).toBe("ft")
-    expect(sea_surface_height_above_geopotential_datum.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(sea_surface_height_above_geopotential_datum.displayName(UnitSystem.metric)).toBe("m")
   })
 })

--- a/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_higher_high_water.spec.ts
+++ b/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_higher_high_water.spec.ts
@@ -24,7 +24,7 @@ describe("tidal_sea_surface_height_above_mean_higher_high_water conversions", ()
 
   it("display names", () => {
     expect(tidal_sea_surface_height_above_mean_higher_high_water.displayName(UnitSystem.english)).toBe("ft")
-    expect(tidal_sea_surface_height_above_mean_higher_high_water.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(tidal_sea_surface_height_above_mean_higher_high_water.displayName(UnitSystem.metric)).toBe("m")
   })
 })
 

--- a/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_lower_low_water.spec.ts
+++ b/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_lower_low_water.spec.ts
@@ -24,7 +24,7 @@ describe("tidal_sea_surface_height_above_mean_lower_low_water conversions", () =
 
   it("display names", () => {
     expect(tidal_sea_surface_height_above_mean_lower_low_water.displayName(UnitSystem.english)).toBe("ft")
-    expect(tidal_sea_surface_height_above_mean_lower_low_water.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(tidal_sea_surface_height_above_mean_lower_low_water.displayName(UnitSystem.metric)).toBe("m")
   })
 })
 

--- a/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_sea_level.spec.ts
+++ b/src/Features/Units/Converter/data_types/tidal_sea_surface_height_above_mean_sea_level.spec.ts
@@ -20,6 +20,6 @@ describe("tidal_sea_surface_height_above_mean_sea_level conversions", () => {
 
   it("display names", () => {
     expect(tidal_sea_surface_height_above_mean_sea_level.displayName(UnitSystem.english)).toBe("ft")
-    expect(tidal_sea_surface_height_above_mean_sea_level.displayName(UnitSystem.metric)).toBe("Meters")
+    expect(tidal_sea_surface_height_above_mean_sea_level.displayName(UnitSystem.metric)).toBe("m")
   })
 })


### PR DESCRIPTION
@cgalvarino
https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3875 -- Abbreviate units everywhere

"Meters" --> "m" on wave height observations.
Feet were already represented as "ft"

**Notes:** Looks like the "(# feet)" conversion in the chart would be a good candidate for the loose units hunt.

**Before**
<img width="461" height="255" alt="Screenshot 2026-04-16 at 1 29 27 PM" src="https://github.com/user-attachments/assets/7e611a7e-0f07-4668-b6b8-da85cf150c84" />


**After**
<img width="461" height="255" alt="Screenshot 2026-04-16 at 1 29 53 PM" src="https://github.com/user-attachments/assets/cd21ebcc-bc00-41ef-a8b0-b61cfb120a63" />
