### PR TITLE
Seawater speed (cms velocity) units abbreviated

### DIFF
--- a/src/Features/Units/Converter/data_types/_cms_velocity.ts
+++ b/src/Features/Units/Converter/data_types/_cms_velocity.ts
@@ -16,7 +16,7 @@ export class CmsVelocity extends DataTypeConversion {
     public data_type: string,
     public display_name: string,
   ) {
-    super(data_type, display_name, "cm/s", "m/s", "knot", "Meters/Second", "Knots")
+    super(data_type, display_name, "cm/s", "m/s", "knot", "Meters/Second", "Knots", "m/s", "kts")
   }
 
   convertFrom(value: number | string): ConvertFrom {

--- a/src/Features/Units/Converter/data_types/eastward_sea_water_velocity.spec.ts
+++ b/src/Features/Units/Converter/data_types/eastward_sea_water_velocity.spec.ts
@@ -24,7 +24,7 @@ describe("eastward_sea_water_velocity conversions", () => {
   })
 
   it("display names", () => {
-    expect(eastward_sea_water_velocity.displayName(UnitSystem.english)).toBe("Knots")
-    expect(eastward_sea_water_velocity.displayName(UnitSystem.metric)).toBe("Meters/Second")
+    expect(eastward_sea_water_velocity.displayName(UnitSystem.english)).toBe("kts")
+    expect(eastward_sea_water_velocity.displayName(UnitSystem.metric)).toBe("m/s")
   })
 })

--- a/src/Features/Units/Converter/data_types/northward_sea_water_velocity.spec.ts
+++ b/src/Features/Units/Converter/data_types/northward_sea_water_velocity.spec.ts
@@ -24,7 +24,7 @@ describe("northward_sea_water_velocity conversions", () => {
   })
 
   it("display names", () => {
-    expect(northward_sea_water_velocity.displayName(UnitSystem.english)).toBe("Knots")
-    expect(northward_sea_water_velocity.displayName(UnitSystem.metric)).toBe("Meters/Second")
+    expect(northward_sea_water_velocity.displayName(UnitSystem.english)).toBe("kts")
+    expect(northward_sea_water_velocity.displayName(UnitSystem.metric)).toBe("m/s")
   })
 })

--- a/src/Features/Units/Converter/data_types/sea_water_speed.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_water_speed.spec.ts
@@ -24,7 +24,7 @@ describe("sea_water_speed conversions", () => {
   })
 
   it("display names", () => {
-    expect(sea_water_speed.displayName(UnitSystem.english)).toBe("Knots")
-    expect(sea_water_speed.displayName(UnitSystem.metric)).toBe("Meters/Second")
+    expect(sea_water_speed.displayName(UnitSystem.english)).toBe("kts")
+    expect(sea_water_speed.displayName(UnitSystem.metric)).toBe("m/s")
   })
 })

--- a/src/Features/Units/Converter/data_types/sea_water_velocity.spec.ts
+++ b/src/Features/Units/Converter/data_types/sea_water_velocity.spec.ts
@@ -24,7 +24,7 @@ describe("sea_water_velocity conversions", () => {
   })
 
   it("display names", () => {
-    expect(sea_water_velocity.displayName(UnitSystem.english)).toBe("Knots")
-    expect(sea_water_velocity.displayName(UnitSystem.metric)).toBe("Meters/Second")
+    expect(sea_water_velocity.displayName(UnitSystem.english)).toBe("kts")
+    expect(sea_water_velocity.displayName(UnitSystem.metric)).toBe("m/s")
   })
 })

--- a/src/Features/Units/Converter/data_types/wind_gust.spec.ts
+++ b/src/Features/Units/Converter/data_types/wind_gust.spec.ts
@@ -24,7 +24,7 @@ describe("wind_gust conversions", () => {
   })
 
   it("display names", () => {
-    expect(wind_gust.displayName(UnitSystem.english)).toBe("Knots")
-    expect(wind_gust.displayName(UnitSystem.metric)).toBe("Meters/Second")
+    expect(wind_gust.displayName(UnitSystem.english)).toBe("kts")
+    expect(wind_gust.displayName(UnitSystem.metric)).toBe("m/s")
   })
 })

--- a/src/Features/Units/Converter/data_types/wind_min.spec.ts
+++ b/src/Features/Units/Converter/data_types/wind_min.spec.ts
@@ -24,7 +24,7 @@ describe("wind_min conversions", () => {
   })
 
   it("display names", () => {
-    expect(wind_min.displayName(UnitSystem.english)).toBe("Knots")
-    expect(wind_min.displayName(UnitSystem.metric)).toBe("Meters/Second")
+    expect(wind_min.displayName(UnitSystem.english)).toBe("kts")
+    expect(wind_min.displayName(UnitSystem.metric)).toBe("m/s")
   })
 })

--- a/src/Features/Units/Converter/data_types/wind_peak.spec.ts
+++ b/src/Features/Units/Converter/data_types/wind_peak.spec.ts
@@ -24,7 +24,7 @@ describe("wind_peak conversions", () => {
   })
 
   it("display names", () => {
-    expect(wind_peak.displayName(UnitSystem.english)).toBe("Knots")
-    expect(wind_peak.displayName(UnitSystem.metric)).toBe("Meters/Second")
+    expect(wind_peak.displayName(UnitSystem.english)).toBe("kts")
+    expect(wind_peak.displayName(UnitSystem.metric)).toBe("m/s")
   })
 })

--- a/src/Features/Units/Converter/index.spec.ts
+++ b/src/Features/Units/Converter/index.spec.ts
@@ -10,7 +10,7 @@ describe("Unit converter", () => {
     const dataConverter = converter(data_type)
 
     expect(dataConverter.convertTo(source_value, UnitSystem.english)).toBeCloseTo(19.4384)
-    expect(dataConverter.displayName(UnitSystem.english)).toBe("Knots")
+    expect(dataConverter.displayName(UnitSystem.english)).toBe("kts")
   })
 
   it("Does not explode and return an invalid data type silently", () => {

--- a/src/components/Charts/formatter.spec.ts
+++ b/src/components/Charts/formatter.spec.ts
@@ -18,7 +18,7 @@ describe("pointFormatMaker", () => {
 
     const result = pointFormatter()
 
-    expect(result).toContain("Meters/Second")
+    expect(result).toContain("m/s")
     expect(result).toContain(thisObject.y.toString())
   })
 })


### PR DESCRIPTION
@cgalvarino
https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3875 -- Abbreviate units everywhere

"Meters/Second" -> "m/s"
"Knots" -> "kts" 

**Notes:**
- Went with "kts" to stay consistent while we deliberate on the convention in #4070 
- I was unable to find a station that was actually reporting visibility, so was unable to manually test these changes. Storybook & Playwright are green.