### PR TITLE
Station hover popup -- clean approach

### DIFF
--- a/src/Features/ERDDAP/Map/StationPopup.tsx
+++ b/src/Features/ERDDAP/Map/StationPopup.tsx
@@ -1,0 +1,35 @@
+interface Props {
+  platformId: string
+}
+
+const PopupMetric = () => {
+  return (
+    <div className="caption d-flex flex-row gap-1">
+      <strong>Metric name:</strong>
+      <span>val</span>
+      <span>unit</span>
+    </div>
+  )
+}
+
+const LastUpdated = () => {
+  return (
+    <span className="caption d-flex gap-1">
+      <strong>Last updated:</strong>
+      <span> time updated</span>
+    </span>
+  )
+}
+
+export const StationPopup = ({ platformId }: Props) => {
+  return (
+    <div className="d-flex flex-column justify-content-start">
+      <p className="m-0 d-flex justify-content-start">
+        <strong>Station: {platformId}</strong>
+      </p>
+      <LastUpdated />
+      <PopupMetric />
+      <PopupMetric />
+    </div>
+  )
+}

--- a/src/Features/ERDDAP/Map/StationPopup.tsx
+++ b/src/Features/ERDDAP/Map/StationPopup.tsx
@@ -81,7 +81,8 @@ const LastUpdated = ({ allData }: { allData: PlatformTimeSeries[] }) => {
 const DataRenderer = ({ platform }: DataRendererProps) => {
   const limit = 2
   let { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, aDayAgoRounded())
-  allCurrentConditionsTimeseries = allCurrentConditionsTimeseries.slice(0, limit)
+  //   Uncomment below to work on "top 2 conditions"
+  //   allCurrentConditionsTimeseries = allCurrentConditionsTimeseries.slice(0, limit)
   return (
     <React.Fragment>
       <LastUpdated allData={allCurrentConditionsTimeseries} />

--- a/src/Features/ERDDAP/Map/StationPopup.tsx
+++ b/src/Features/ERDDAP/Map/StationPopup.tsx
@@ -1,35 +1,114 @@
+import * as React from "react"
+
+import { useUnitSystem } from "Features/Units"
+import { converter } from "Features/Units/Converter"
+import { round } from "Shared/math"
+import { aDayAgoRounded } from "Shared/time"
+import { UsePlatform } from "Features/ERDDAP/hooks/BuoyBarnComponents"
+import { currentConditionsTimeseries } from "../utils/currentConditionsTimeseries"
+import { PlatformFeature, PlatformTimeSeries } from "../types"
+import { DataTypeConversion } from "Features/Units/Converter/conversions"
+import { UnitSystem } from "Features/Units/types"
+
 interface Props {
   platformId: string
 }
 
-const PopupMetric = () => {
+interface DataRendererProps {
+  platform: PlatformFeature
+}
+
+type popupData = {
+  name: string | undefined
+  value: number | string
+  unit_converter: DataTypeConversion
+}
+
+const getPopupData = (data: PlatformTimeSeries, unitSystem: UnitSystem): popupData => {
+  const shortNameThreshold: number = 50
+  let name = data.data_type.long_name.length > shortNameThreshold ? data.data_type.short_name : data.data_type.long_name
+
+  if (data.depth && data.depth > 0) {
+    name = `${name} @ ${data.depth}m`
+  }
+
+  const unit_converter = converter(data.data_type.standard_name)
+  const value = unit_converter.convertTo(data.value as number, unitSystem)
+
+  return { name: name, unit_converter: unit_converter, value: value }
+}
+
+const getTimes = (data: PlatformTimeSeries[]): Date[] => {
+  const times = data.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
+  return times.sort((a, b) => a.valueOf() - b.valueOf())
+}
+
+const StationName = ({ platform }: DataRendererProps) => {
+  return (
+    <p className="m-0 d-flex justify-content-start">
+      <strong>Station: {platform.id}</strong>
+    </p>
+  )
+}
+
+const PopupMetric = ({ data }: { data: PlatformTimeSeries }) => {
+  const unitSystem = useUnitSystem()
+  const popupData: popupData = getPopupData(data, unitSystem)
+  const value = popupData.value
+
   return (
     <div className="caption d-flex flex-row gap-1">
-      <strong>Metric name:</strong>
-      <span>val</span>
-      <span>unit</span>
+      <strong>{popupData.name}</strong>
+      <span>{typeof value === "number" ? round(value as number, 1) : value}</span>
+      <span>{popupData.unit_converter.displayName(unitSystem)}</span>
     </div>
   )
 }
 
-const LastUpdated = () => {
+const LastUpdated = ({ allData }: { allData: PlatformTimeSeries[] }) => {
+  const times = getTimes(allData)
+  if (times.length <= 0) {
+    return null
+  }
+  const timeVal = times[times.length - 1].toLocaleString(undefined, {
+    hour: "2-digit",
+    hour12: true,
+    minute: "2-digit",
+    month: "short",
+    day: "numeric",
+  })
+
   return (
     <span className="caption d-flex gap-1">
       <strong>Last updated:</strong>
-      <span> time updated</span>
+      <span> {timeVal}</span>
     </span>
+  )
+}
+
+const DataRenderer = ({ platform }: DataRendererProps) => {
+  const limit = 2
+  let { allCurrentConditionsTimeseries } = currentConditionsTimeseries(platform, aDayAgoRounded())
+  allCurrentConditionsTimeseries = allCurrentConditionsTimeseries.slice(0, limit)
+  return (
+    <React.Fragment>
+      <LastUpdated allData={allCurrentConditionsTimeseries} />
+      {allCurrentConditionsTimeseries.map((timeSeries, index) => (
+        <PopupMetric key={index} data={timeSeries} />
+      ))}
+    </React.Fragment>
   )
 }
 
 export const StationPopup = ({ platformId }: Props) => {
   return (
-    <div className="d-flex flex-column justify-content-start">
-      <p className="m-0 d-flex justify-content-start">
-        <strong>Station: {platformId}</strong>
-      </p>
-      <LastUpdated />
-      <PopupMetric />
-      <PopupMetric />
-    </div>
+    <UsePlatform platformId={platformId}>
+      {({ platform }) => (
+        <div className="d-flex flex-column justify-content-start">
+          <StationName platform={platform} />
+          <DataRenderer platform={platform} />
+        </div>
+      )}
+    </UsePlatform>
   )
 }

--- a/src/Features/ERDDAP/Map/StationPopup.tsx
+++ b/src/Features/ERDDAP/Map/StationPopup.tsx
@@ -50,7 +50,7 @@ const PopupMetric = ({ data }: { data: PlatformTimeSeries }) => {
 
   return (
     <div className="caption d-flex flex-row gap-1">
-      <strong>{popupData.name}</strong>
+      <strong>{`${popupData.name}:`}</strong>
       <span>{typeof value === "number" ? round(value as number, 1) : value}</span>
       <span>{popupData.unit_converter.displayName(unitSystem)}</span>
     </div>

--- a/src/Features/ERDDAP/Map/StationPopup.tsx
+++ b/src/Features/ERDDAP/Map/StationPopup.tsx
@@ -43,14 +43,6 @@ const getTimes = (data: PlatformTimeSeries[]): Date[] => {
   return times.sort((a, b) => a.valueOf() - b.valueOf())
 }
 
-const StationName = ({ platform }: DataRendererProps) => {
-  return (
-    <p className="m-0 d-flex justify-content-start">
-      <strong>Station: {platform.id}</strong>
-    </p>
-  )
-}
-
 const PopupMetric = ({ data }: { data: PlatformTimeSeries }) => {
   const unitSystem = useUnitSystem()
   const popupData: popupData = getPopupData(data, unitSystem)
@@ -97,6 +89,14 @@ const DataRenderer = ({ platform }: DataRendererProps) => {
         <PopupMetric key={index} data={timeSeries} />
       ))}
     </React.Fragment>
+  )
+}
+
+const StationName = ({ platform }: DataRendererProps) => {
+  return (
+    <p className="m-0 d-flex justify-content-start">
+      <strong>Station: {platform.id}</strong>
+    </p>
   )
 }
 

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -25,6 +25,7 @@ import { usePlatforms } from "../hooks"
 import { PlatformFeature } from "../types"
 import { platformName } from "../utils/platformName"
 import { Feature } from "ol"
+import { StationPopup } from "./StationPopup"
 
 export interface Props {
   // Bounding box for fitting to a region
@@ -122,7 +123,7 @@ export const PlatformLayer = ({ platform, selected, old = false }: PlatformLayer
               [router, url],
             )}
           >
-            {platformName(platform)}
+            <StationPopup platformId={platform.id} />
           </Button>
         </RPopup>
       </RFeature>

--- a/tests/e2e/Home/home.spec.ts
+++ b/tests/e2e/Home/home.spec.ts
@@ -38,8 +38,8 @@ test.describe("Home page", function () {
   test("Has superlatives", async ({ page }) => {
     await page.goto("/")
     await expect(page.getByText(/Highest Winds/).first()).toBeVisible()
-    await expect(page.getByText(/kts/).first()).toBeVisible()
+    await expect(page.getByText(/\d+\s+kts/)).toBeVisible()
     await expect(page.getByText(/Biggest Waves/).first()).toBeVisible()
-    await expect(page.getByText(/ft/).first()).toBeVisible()
+    await expect(page.getByText(/\d+\s+ft/).first()).toBeVisible()
   })
 })


### PR DESCRIPTION
@cgalvarino 
Addresses: https://github.com/gulfofmaine/Neracoos-1-Buoy-App/issues/3876
Updated Station Hover Popup

Build for a map popup component which displays either a limited number of or all current conditions at a given station. Adapts a version of the `ErddapObservationTable` component by using the same approach with a `UsePlatform` wrapper/hook to access platform data for a given ID.

The helper functions `getData` and `getTimes` contain code duplicated from [Table/item.tsx](src/Features/ERDDAP/Platform/Observations/Table/item.tsxl).

**Before**
<img width="194" height="78" alt="Screenshot 2026-04-17 at 4 27 11 PM" src="https://github.com/user-attachments/assets/e45386d5-2558-4704-be60-8907d19ae1bb" />

**After**
<img width="329" height="272" alt="Screenshot 2026-04-17 at 4 26 52 PM" src="https://github.com/user-attachments/assets/7417276e-7c81-4c7b-a37d-e5a8a669dc0c" />
