### PR TITLE
one popup per map instead of one popup per feature

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -105,27 +105,11 @@ export const PlatformLayer = ({ platform, selected, old = false }: PlatformLayer
       </RStyle.RStyle>
       <RFeature
         geometry={geometry}
+        properties={{ platform: platform, url: url }}
         onClick={useCallback(() => {
           router.push(url)
         }, [router, url])}
-      >
-        <RPopup trigger={"hover"}>
-          <Button
-            variant="dark"
-            size="sm"
-            href={url}
-            onClick={useCallback(
-              (event) => {
-                event.preventDefault()
-                router.push(url)
-              },
-              [router, url],
-            )}
-          >
-            {platformName(platform)}
-          </Button>
-        </RPopup>
-      </RFeature>
+      ></RFeature>
     </RLayerVector>
   )
 }
@@ -138,6 +122,35 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
   const params: { regionId?: string; platformId?: string } = useParams()
   const [view, setView] = useState<View>(initial)
   const path = usePathname()
+
+  const [highlightedFeatures, setHighlightedFeatures] = useState<any[]>([])
+  const popup = useRef<RPopup>(null)
+
+  const onPointerMove = useCallback((e) => {
+    const features: any[] = []
+
+    // Use a single popup element based on the topmost moused-over platform.
+    // Instead of having one popup per platform which was a clobbering mess.
+
+    // Access the underlying OpenLayers map object from the event
+    const map = e.map
+
+    // Iterate through all features at the current pixel
+    map.forEachFeatureAtPixel(e.pixel, (feature) => {
+      features.push(feature)
+      // stop at the first (topmost) feature
+      return true
+    })
+
+    // Save off the feature(s) and take some popup action.
+    if (features.length > 0) {
+      setHighlightedFeatures(features)
+      popup.current?.show()
+    } else {
+      setHighlightedFeatures([])
+      popup.current?.hide()
+    }
+  }, [])
 
   // Check if the route was navigated to using the back button
   // const isBackButtonUsed = router.asPath !== router.pathname;
@@ -178,9 +191,29 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, heig
   const { oldPlatforms, filteredPlatforms, selectedPlatforms } = filterPlatforms(platforms, platformId)
 
   return (
-    <RMap ref={mapRef} className="map" initial={initial} view={[view || initial, setView]} height={height}>
+    <RMap
+      ref={mapRef}
+      className="map"
+      initial={initial}
+      view={[view || initial, setView]}
+      height={height}
+      onPointerMove={onPointerMove}
+    >
       <EsriOceanBasemapLayer />
       <EsriOceanReferenceLayer />
+
+      {highlightedFeatures.length > 0 && (
+        <RLayerVector>
+          <RStyle.RStyle />
+          <RFeature feature={highlightedFeatures[0]}>
+            <RPopup ref={popup}>
+              <Button variant="dark" size="sm" href={highlightedFeatures[0].get("url")}>
+                {platformName(highlightedFeatures[0].get("platform"))}
+              </Button>
+            </RPopup>
+          </RFeature>
+        </RLayerVector>
+      )}
 
       {oldPlatforms.map((p) => (
         <PlatformLayer key={p.id} platform={p} selected={false} old={true} />


### PR DESCRIPTION
Enough clobbering tooltips, already!

Before: One RPopup per feature.

After:  One RPopup per map.  The map now has an onPointerMove listener.  This listener is smart enough to pick the topmost platform dot to use for the RPopup guts.

@shindelr @abkfenris 