### PR TITLE
44x44 (ish) mobile platform dots

### DIFF
--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -67,9 +67,9 @@ export const PlatformLayer = ({ platform, selected, old = false }: PlatformLayer
 
   let radius: number
   if (selected) {
-    radius = window.innerWidth > adjustPxWidth ? 10 : 15
+    radius = window.innerWidth > adjustPxWidth ? 10 : 30
   } else {
-    radius = window.innerWidth > adjustPxWidth ? 5 : 10
+    radius = window.innerWidth > adjustPxWidth ? 5 : 20
   }
   const opacity = selected ? "cc" : "7a"
 


### PR DESCRIPTION
From 22x22 to 44x44:
<img width="781" height="710" alt="image" src="https://github.com/user-attachments/assets/2b958541-cba8-4f19-b59d-fca2c553cf42" />

This may be too much of a good thing?

@abkfenris @shindelr 