### PR TITLE
Top OBS info icon & map icon size

### DIFF
--- a/src/Features/ERDDAP/Superlatives/index.tsx
+++ b/src/Features/ERDDAP/Superlatives/index.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react"
 import Card from "react-bootstrap/Card"
 import Col from "react-bootstrap/Col"
 import Row from "react-bootstrap/Row"
+import { Tooltip, OverlayTrigger } from "react-bootstrap"
 
 import { WarningAlert } from "components/Alerts"
 import { useUnitSystem } from "Features/Units"
@@ -17,6 +18,7 @@ import { paths } from "Shared/constants"
 import { round } from "Shared/math"
 import { anHourAgoRounded, hoursBefore } from "Shared/time"
 import { urlPartReplacer } from "Shared/urlParams"
+import { InfoCircleIcon } from "Shared/icons/iconsMap"
 
 import { usePlatforms } from "../hooks/buoyBarn"
 import { PlatformFeature, PlatformTimeSeries } from "../types"
@@ -105,10 +107,30 @@ export const ShowSuperlatives: React.FunctionComponent<ShowSuperlativesProps> = 
       }
     }
   }, [platforms, searchStartTime])
+
+  const renderToolTip = (props) => {
+    if (windSuperlative?.timeSeries?.time && waveSuperlative?.timeSeries?.time) {
+      return (
+        <Tooltip {...props} id="superlatives-tooltip" className="superlatives-tooltip">
+          <div>{`Wave observation from: ${new Date(waveSuperlative.timeSeries.time).toLocaleString()}`}</div>
+          <div>{`Wind observation from: ${new Date(windSuperlative.timeSeries.time).toLocaleString()}`}</div>
+        </Tooltip>
+      )
+    } else {
+      return (
+        <Tooltip {...props} id="superlatives-tooltip">
+          Data not available.
+        </Tooltip>
+      )
+    }
+  }
   return (
     <Card className="mt-5">
-      <Card.Header className="d-flex flex-row align-items-center bg-black bg-opacity-5">
+      <Card.Header className="d-flex flex-row gap-2 align-items-center bg-black bg-opacity-5">
         <h3 className="d-flex m-0">Top Wind & Waves - All Regions</h3>
+        <OverlayTrigger placement="right" delay={{ show: 250, hide: 250 }} overlay={renderToolTip}>
+          <InfoCircleIcon className="fa-md" />
+        </OverlayTrigger>
       </Card.Header>
 
       <Card.Body>

--- a/src/Features/ERDDAP/Superlatives/index.tsx
+++ b/src/Features/ERDDAP/Superlatives/index.tsx
@@ -112,8 +112,8 @@ export const ShowSuperlatives: React.FunctionComponent<ShowSuperlativesProps> = 
     if (windSuperlative?.timeSeries?.time && waveSuperlative?.timeSeries?.time) {
       return (
         <Tooltip {...props} id="superlatives-tooltip" className="superlatives-tooltip">
-          <div>{`Wave observation from: ${new Date(waveSuperlative.timeSeries.time).toLocaleString()}`}</div>
           <div>{`Wind observation from: ${new Date(windSuperlative.timeSeries.time).toLocaleString()}`}</div>
+          <div>{`Wave observation from: ${new Date(waveSuperlative.timeSeries.time).toLocaleString()}`}</div>
         </Tooltip>
       )
     } else {

--- a/src/index.scss
+++ b/src/index.scss
@@ -265,7 +265,7 @@ $dig-opacities: (
   right: 10px;
 }
 
-@include media-breakpoint-down(md){
+@include media-breakpoint-down(md) {
   .ol-touch .ol-control button {
     font-size: 1.25rem;
     height: 44px;

--- a/src/index.scss
+++ b/src/index.scss
@@ -236,6 +236,11 @@ $dig-opacities: (
   }
 }
 
+.ol-touch .ol-control button {
+  font-size: 1.25rem;
+  height: 44px;
+  width: 44px;
+}
 // ========== MAP END ============
 
 .superlatives-tooltip .tooltip-inner {
@@ -257,18 +262,6 @@ $dig-opacities: (
 
 .tooltip-inner a {
   color: $coastal-meadow;
-}
-
-.map .ol-zoom {
-  top: 10px;
-  left: auto;
-  right: 10px;
-}
-
-.ol-touch .ol-control button {
-  font-size: 1.25rem;
-  height: 44px;
-  width: 44px;
 }
 
 .legend-item {

--- a/src/index.scss
+++ b/src/index.scss
@@ -259,6 +259,20 @@ $dig-opacities: (
   color: $coastal-meadow;
 }
 
+.map .ol-zoom {
+  top: 10px;
+  left: auto;
+  right: 10px;
+}
+
+@include media-breakpoint-down(md){
+  .ol-touch .ol-control button {
+    font-size: 1.25rem;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 .legend-item {
   position: relative;
   display: flex;

--- a/src/index.scss
+++ b/src/index.scss
@@ -238,6 +238,10 @@ $dig-opacities: (
 
 // ========== MAP END ============
 
+.superlatives-tooltip .tooltip-inner {
+  max-width: none;
+}
+
 .condition-tooltip > div > div {
   background-color: $primary;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -265,12 +265,10 @@ $dig-opacities: (
   right: 10px;
 }
 
-@include media-breakpoint-down(md) {
-  .ol-touch .ol-control button {
-    font-size: 1.25rem;
-    height: 44px;
-    width: 44px;
-  }
+.ol-touch .ol-control button {
+  font-size: 1.25rem;
+  height: 44px;
+  width: 44px;
 }
 
 .legend-item {


### PR DESCRIPTION
@cgalvarino 
#3876 

Adjusted map icon size to be 44px x 44px on mobile.
Added info icon to top wind and waves card on landing which displays last updated time stamp.

**Icon Size**
On mobile, increase size of icons on map to be 44x44 px to ensure large enough touch target

**Latest Conditions**
Renamed title to ‘Top Wind & Waves—All Regions’ (H3)
Moved to the right of the map
**Added info icon popup to house Last Updated timestamp and other information**
Background color: Black 5
Text styles (in order): ’Paragraph Bold’, ‘Paragraph’, ‘Link’
Title & Paragraph color: Black
Link color: Blue

**Before**
<img width="693" height="196" alt="Screenshot 2026-04-20 at 4 01 21 PM" src="https://github.com/user-attachments/assets/6a448309-300a-4a64-9c5c-6ee3bfaa446c" />


**After**
<img width="693" height="196" alt="Screenshot 2026-04-20 at 4 00 53 PM" src="https://github.com/user-attachments/assets/08f1f36e-8433-4e85-828b-44fabf8c0493" />
