### PR TITLE
Push on main and tags

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,10 @@ name: "Push"
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - "v*"
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Avoid duplicate Actions workflow runs on pull requests by limiting push actions to the main branch and tags.