### PR TITLE
Increase timeouts on ERDDAP requests to 30 seconds

### DIFF
--- a/src/Features/ERDDAP/hooks/tabledap.ts
+++ b/src/Features/ERDDAP/hooks/tabledap.ts
@@ -29,7 +29,7 @@ export const getDataset = (timeSeries: PlatformTimeSeries, startTime?: Date, end
     })
 
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 5000)
+    const timeoutId = setTimeout(() => controller.abort(), 30000)
 
     const result = await fetch(url, { signal: controller.signal })
 


### PR DESCRIPTION
Currently we are timing out requests to ERDDAP after 5 seconds. Tanstack-query then retries the request a few times before giving up. 

I believe that the way this was causing Buoy Barn to have multiple of the same request in flight to ERDDAP at the same as it’s timeout was 30 seconds. This may have caused ERDDAP to get flustered and not respond, which was causing other things to get locked up and fail to respond as well.

xref https://github.com/gulfofmaine/buoy_barn/pull/1687