### PR TITLE
Region list map height fix

### DIFF
--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -48,11 +48,13 @@ export default function Layout({
 
         <Col xs={12} md={6} className="order-1 d-flex flex-column">
           <div className="platform-map-layout flex-fill position-relative">
-            <ErddapMap
-              // Pass minimum height requirement only on landing page
-              className={`${!(isPlatformView || isRegionView) ? "landing-min-height" : ""} map`}
-              {...(isPlatformView && { platformId })}
-            />
+            <div className={isRegionView ? "region-map-container" : "d-flex h-100"}>
+              <ErddapMap
+                // Pass minimum height requirement only on landing page
+                className={`${!(isPlatformView || isRegionView) ? "landing-min-height" : ""} map`}
+                {...(isPlatformView && { platformId })}
+              />
+            </div>
           </div>
 
           {/* Below Map = Superlatives */}

--- a/src/index.scss
+++ b/src/index.scss
@@ -191,11 +191,20 @@ $dig-opacities: (
   }
 }
 
+.region-map-container {
+  height: 100%;
+  display: flex;
+  min-height: 85vh;
+}
+
 // Mobile landscape view
 @media (max-height: 500px) {
   @include media-breakpoint-up(md) {
     .sidebar-height {
       max-height: 75vh;
+    }
+    .region-map-container {
+      min-height: 75vh;
     }
   }
 }
@@ -233,6 +242,10 @@ $dig-opacities: (
   }
   .sidebar-height {
     height: unset;
+  }
+  .region-map-container {
+    height: unset;
+    min-height: unset;
   }
 }
 


### PR DESCRIPTION
@cgalvarino 
#3879

Map height flexes with viewport but stays constant on region list.

<img width="1440" height="813" alt="Screenshot 2026-04-24 at 9 55 34 AM" src="https://github.com/user-attachments/assets/f70156b2-1cca-45f9-8a86-0cc8b48f1817" />

<img width="1440" height="813" alt="Screenshot 2026-04-24 at 9 55 26 AM" src="https://github.com/user-attachments/assets/5be5d92f-1501-4baf-8579-0de113dbb1fe" />
