### PR TITLE
Tightened whitespace around map

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="App d-flex flex-column min-vh-100 overflow-x-hidden">
           <Providers>
             <NavBar />
-            <Container fluid className="p-0 px-5 px-lg-10">
+            <Container fluid className="p-0 px-5">
               {children}
             </Container>
             <Footer />

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -41,7 +41,7 @@ const NeracoosNavBar = () => {
   return (
     <div>
       <Navbar data-bs-theme="dark" className="bg-primary mb-4 dark-nav-custom" expand="md">
-        <Container fluid className="mx-5 mx-lg-10 px-0">
+        <Container fluid className="mx-5 px-0">
           <Navbar.Brand href={paths.home}>
             <div className="d-flex flex-column flex-md-row align-items-md-center gap-2 gap-md-4">
               <Image src={neracoosLogo} alt="NERACOOS" height={30} width={209} />


### PR DESCRIPTION
@cgalvarino 
#3875 

Removed desktop 40px margins. Just for a reminder to have it here, the original Dig specs are shown below:
<img width="718" height="489" alt="Screenshot 2026-04-24 at 10 17 28 AM" src="https://github.com/user-attachments/assets/5132c8e1-5118-405b-8198-f83dc5cccebf" />

We decided to move forward with **20px** margins/padding on Desktop/Tablet **and** mobile.