### PR TITLE
Adjusted map key text

### DIFF
--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -122,7 +122,7 @@ const LegendItem = ({ active }: { active: boolean }) => {
   return (
     <span className="caption d-flex flex-row align-items-center">
       <div className={`erddap-key-dot ${active ? "erddap-dot-active" : "erddap-dot-inactive"}`}></div>
-      {active ? "Active" : "Inactive"}
+      {active ? "< 24 hours" : "> 24 hours"}
     </span>
   )
 }
@@ -131,7 +131,7 @@ const LegendItem = ({ active }: { active: boolean }) => {
 const MapLegend = () => {
   return (
     <div className="map-key d-flex flex-column gap-1 bg-white border rounded-1 py-2 px-3">
-      <p className="caption m-0">Station Key</p>
+      <p className="caption m-0">Recent Data</p>
       <LegendItem active={true} />
       <LegendItem active={false} />
     </div>


### PR DESCRIPTION
@cgalvarino 

Adjusted map key text. This is a deviation from the wireframes provided by Dig. Original specs and after show below.

**Before**
<img width="222" height="166" alt="Screenshot 2026-04-24 at 11 03 05 AM" src="https://github.com/user-attachments/assets/ed683443-ff9f-4bb7-aca0-b3a763bd5978" />

**After**
<img width="222" height="166" alt="Screenshot 2026-04-24 at 11 02 49 AM" src="https://github.com/user-attachments/assets/d74d83e8-c1c8-47f2-b261-d3b5b845c1bd" />

