### PR TITLE
Map drag bugfix for clobberville

### DIFF
--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -27,6 +27,7 @@ import { PlatformFeature } from "../types"
 import { platformName } from "../utils/platformName"
 import { Feature } from "ol"
 import { StationPopup } from "./StationPopup"
+import { feature } from "@turf/helpers"
 
 export interface Props {
   // Bounding box for fitting to a region
@@ -147,11 +148,23 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, clas
   const [view, setView] = useState<View>(initial)
   const path = usePathname()
 
-  const [highlightedFeatures, setHighlightedFeatures] = useState<any[]>([])
+  const [highlightedFeature, setHighlightedFeature] = useState<any | null>(null)
+  const highlightedFeatureRef = useRef<any | null>(null)
   const popup = useRef<RPopup>(null)
 
+  // Re-render the map to show the popup, but only if the highlighted feature changes
+  useEffect(() => {
+    if (highlightedFeature) {
+      popup.current?.show()
+    } else {
+      popup.current?.hide()
+    }
+  }, [highlightedFeature])
+
   const onPointerMove = useCallback((e) => {
-    const features: any[] = []
+    // If you're just dragging around, short circuit the callback
+    if (e.dragging) return
+    let upperFeature = null
 
     // Use a single popup element based on the topmost moused-over platform.
     // Instead of having one popup per platform which was a clobbering mess.
@@ -161,18 +174,15 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, clas
 
     // Iterate through all features at the current pixel
     map.forEachFeatureAtPixel(e.pixel, (feature) => {
-      features.push(feature)
+      upperFeature = feature
       // stop at the first (topmost) feature
       return true
     })
 
-    // Save off the feature(s) and take some popup action.
-    if (features.length > 0) {
-      setHighlightedFeatures(features)
-      popup.current?.show()
-    } else {
-      setHighlightedFeatures([])
-      popup.current?.hide()
+    // Save off the feature(s)
+    if (highlightedFeatureRef.current !== upperFeature){
+      highlightedFeatureRef.current = upperFeature
+      setHighlightedFeature(upperFeature)
     }
   }, [])
 
@@ -221,13 +231,13 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, clas
       <EsriOceanReferenceLayer />
       <MapLegend />
 
-      {highlightedFeatures.length > 0 && (
+      {highlightedFeature && (
         <RLayerVector>
           <RStyle.RStyle />
-          <RFeature feature={highlightedFeatures[0]}>
+          <RFeature feature={highlightedFeature}>
             <RPopup ref={popup}>
-              <Button variant="dark" size="sm" href={highlightedFeatures[0].get("url")}>
-                <StationPopup platformId={highlightedFeatures[0].get("platform_id")} />
+              <Button variant="dark" size="sm" href={highlightedFeature.get("url")}>
+                <StationPopup platformId={highlightedFeature.get("platform_id")} />
               </Button>
             </RPopup>
           </RFeature>

--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -180,7 +180,7 @@ export const ErddapMapBase: React.FC<BaseProps> = ({ platforms, platformId, clas
     })
 
     // Save off the feature(s)
-    if (highlightedFeatureRef.current !== upperFeature){
+    if (highlightedFeatureRef.current !== upperFeature) {
       highlightedFeatureRef.current = upperFeature
       setHighlightedFeature(upperFeature)
     }


### PR DESCRIPTION
@cgalvarino 

Bug fix for the map drag re-render problem for the non-clobbering popups.

Notable changes from OG implementation:
- **highlightedFeatures: any[] -> highlightedFeature: any**: Figured if we're only putting one value in there, probably doesn't need to be an array.
- **Added highlightedFeatureRef**: Need this to keep track of and what feature is hovered over and change the state on highlightedFeature without doing it constantly.
- **Moved the popup show and hide logic to useEffect**: Forces the map to re-render and show/hide the popup whenever highlightedFeature changes, but only when it changes. 