### PR TITLE
Large graph title & export icon

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/Condition/Info.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/Info.tsx
@@ -6,6 +6,7 @@ import Popover from "react-bootstrap/Popover"
 import ListGroup from "react-bootstrap/ListGroup"
 
 import { tabledapProtocolUrl } from "Shared/erddap/tabledap"
+import { ExportIcon } from "Shared/icons/iconsMap"
 
 import { PlatformTimeSeries } from "../../../types"
 
@@ -64,11 +65,7 @@ export const Info: React.FC<InfoProps> = ({ timeSeries, id, startDate }: InfoPro
   return (
     <React.Fragment>
       <OverlayTrigger delay={{ show: 250, hide: 4000 }} overlay={renderToolTip} trigger={["click"]}>
-        <FontAwesomeIcon
-          id={`tooltip-${id}-trigger`}
-          icon={faInfoCircle}
-          style={{ fontSize: "1rem", verticalAlign: "middle" }}
-        />
+        <ExportIcon id={`tooltip-${id}-trigger`} className="export-icon-border bg-white p-1" />
       </OverlayTrigger>
     </React.Fragment>
   )

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -3,8 +3,6 @@
  */
 import { useSearchParams } from "next/navigation"
 import React, { useState } from "react"
-import Col from "react-bootstrap/Col"
-import Row from "react-bootstrap/Row"
 
 import { PlatformLoadingAlert } from "components/Alerts"
 import { LargeTimeSeriesChart } from "components/Charts/LargeTimeSeries"
@@ -50,37 +48,35 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
     const depth = ts.depth && ts.depth > 0 ? " at " + ts.depth + "m below" : ""
 
     return (
-      <Row key={index}>
-        <Col>
-          <div className="observation-title-container">
-            <h4 className="obervation-title">
-              {ts.data_type.long_name} {depth} <Info timeSeries={[ts]} id={index} startDate={startDate} />
-            </h4>
-            <div className="observation-timeframe-selector">
-              {index === 0 && <TimeframeSelector graphFuture={false} />}
-            </div>
+      <div>
+        <h2 className="d-flex gap-2 justify-content-center align-items-center">
+          {ts.data_type.long_name} {depth} <Info timeSeries={[ts]} id={index} startDate={startDate} />
+        </h2>
+        <div>
+          <div className="observation-timeframe-selector">
+            {index === 0 && <TimeframeSelector graphFuture={false} />}
           </div>
-          <UseDataset
-            timeSeries={ts}
-            startTime={startDate}
-            endTime={endDate}
-            loading={<PlatformLoadingAlert time_series={ts} />}
-          >
-            {({ dataset }) => (
-              <ChartTimeSeriesDisplay
-                {...{ dataset, standardName, unitSystem }}
-                timeSeries={ts}
-                startTime={startDate}
-                endTime={endDate}
-              />
-            )}
-          </UseDataset>
-        </Col>
-      </Row>
+        </div>
+        <UseDataset
+          timeSeries={ts}
+          startTime={startDate}
+          endTime={endDate}
+          loading={<PlatformLoadingAlert time_series={ts} />}
+        >
+          {({ dataset }) => (
+            <ChartTimeSeriesDisplay
+              {...{ dataset, standardName, unitSystem }}
+              timeSeries={ts}
+              startTime={startDate}
+              endTime={endDate}
+            />
+          )}
+        </UseDataset>
+      </div>
     )
   })
 
-  return <div style={{ textAlign: "center" }}>{charts}</div>
+  return charts
 }
 
 interface ChartTimeSeriesDisplayProps {

--- a/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
@@ -71,25 +71,21 @@ export const ErddapWindObservedConditionDisplay: React.FunctionComponent<Display
   const { speed, gust, direction } = pickWindDatasets(platform, datasets)
 
   return (
-    <Row>
-      <Col>
-        <div className="observation-title-container">
-          <h4 className="obervation-title">
-            Wind <Info timeSeries={timeSeries} id={0} startDate={startDate} />
-          </h4>
-          <div className="observation-timeframe-selector">
-            <TimeframeSelector graphFuture={false} />
-          </div>
-        </div>
-        <WindTimeSeriesChart
-          barbsPerDay={5}
-          legend={true}
-          {...{ speed, gust, direction, unitSystem }}
-          startTime={startDate}
-          endTime={endDate}
-        />
-      </Col>
-    </Row>
+    <div>
+      <h2 className="d-flex gap-2 justify-content-center align-items-center">
+        Wind <Info timeSeries={timeSeries} id={0} startDate={startDate} />
+      </h2>
+      <div className="observation-timeframe-selector">
+        <TimeframeSelector graphFuture={false} />
+      </div>
+      <WindTimeSeriesChart
+        barbsPerDay={5}
+        legend={true}
+        {...{ speed, gust, direction, unitSystem }}
+        startTime={startDate}
+        endTime={endDate}
+      />
+    </div>
   )
 }
 

--- a/src/Shared/icons/iconComponent.tsx
+++ b/src/Shared/icons/iconComponent.tsx
@@ -2,12 +2,11 @@
  * An abstracted component wrapper for FontAwesome iconography.
  */
 
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { FontAwesomeIcon, FontAwesomeIconProps } from "@fortawesome/react-fontawesome"
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core"
 
-type IconProps = {
+interface IconProps extends Omit<FontAwesomeIconProps, "icon"> {
   className?: string
-  height?: number
 }
 
 function mkIcon(faIcon: IconDefinition) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @import "../node_modules/bootstrap/scss/functions";
 @import "../node_modules/bootstrap/scss/variables";
 @import "../node_modules/bootstrap/scss/variables-dark";
@@ -38,9 +39,9 @@ $dig-colors: (
   "orange": $orange,
 );
 
-$black-20: rgba(0, 0, 0, 0.2);
-$black-65: rgba(0, 0, 0, 0.65);
-$seaweed-10: rgba(23, 133, 150, 0.1);
+$black-20: transparentize($black, 0.2);
+$black-65: transparentize($black, 0.65);
+$seaweed-10: transparentize($seaweed, 0.1);
 
 $font-family-base: "Montserrat", Arial, sans-serif;
 $theme-colors: map-merge($theme-colors, $dig-colors);

--- a/src/index.scss
+++ b/src/index.scss
@@ -38,6 +38,10 @@ $dig-colors: (
   "orange": $orange,
 );
 
+$black-20: rgba(0, 0, 0, 0.2);
+$black-65: rgba(0, 0, 0, 0.65);
+$seaweed-10: rgba(23, 133, 150, 0.1);
+
 $font-family-base: "Montserrat", Arial, sans-serif;
 $theme-colors: map-merge($theme-colors, $dig-colors);
 
@@ -255,6 +259,10 @@ $dig-opacities: (
   width: 44px;
 }
 // ========== MAP END ============
+.export-icon-border {
+  border: 1px solid $black-20;
+  border-radius: 6px;
+}
 
 .superlatives-tooltip .tooltip-inner {
   max-width: none;
@@ -288,8 +296,8 @@ $dig-opacities: (
   z-index: 10;
   top: 1rem;
   left: 1rem;
-  color: rgba(0, 0, 0, 0.65);
-  border-color: rgba(0, 0, 0, 0.65);
+  color: $black-65;
+  border-color: $black-65;
 }
 
 .erddap-key-dot {
@@ -403,17 +411,6 @@ $dig-opacities: (
   margin-top: 5px;
   vertical-align: middle;
   margin-bottom: 20px;
-}
-
-.observation-title-container {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-}
-
-.obervation-title {
-  grid-column: 2;
-  justify-self: center;
 }
 
 .observation-timeframe-selector {

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -39,7 +39,7 @@ test.describe("Platfrom 44007", () => {
       .first()
       .click()
     await page.getByRole("menuitem", { name: "Wind" }).first().click()
-    await expect(page.locator("h4").getByText(/Wind/).first()).toBeVisible()
+    await expect(page.locator("h2").getByText(/Wind/).first()).toBeVisible()
     await expect(page.locator("svg.highcharts-root")).toBeVisible()
     // cy.get("svg.highcharts-root").contains("Gust").click()
     await page.locator("svg.highcharts-root").getByText(/Speed/).first().click()
@@ -162,7 +162,7 @@ test.describe("Platfrom 44007", () => {
       .click()
     await expect(
       page
-        .locator("h4")
+        .locator("h2")
         .getByText(/Air Temperature/)
         .first(),
     ).toBeVisible()
@@ -175,7 +175,7 @@ test.describe("Platfrom 44007", () => {
     await page.reload()
     await expect(
       page
-        .locator("h4")
+        .locator("h2")
         .getByText(/Air Temperature/)
         .first(),
     ).toBeVisible()

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -45,7 +45,7 @@ test.describe("Platform A01", () => {
       .click()
     await expect(
       page
-        .locator("h4")
+        .locator("h2")
         .getByText(/Air Temperature/)
         .first(),
     ).toBeVisible()
@@ -187,7 +187,7 @@ test.describe("Platform A01", () => {
       .click()
     await expect(
       page
-        .locator("h4")
+        .locator("h2")
         .getByText(/Air Temperature/)
         .first(),
     ).toBeVisible()
@@ -200,7 +200,7 @@ test.describe("Platform A01", () => {
     await page.reload()
     await expect(
       page
-        .locator("h4")
+        .locator("h2")
         .getByText(/Air Temperature/)
         .first(),
     ).toBeVisible()


### PR DESCRIPTION
@cgalvarino 
#3884

Title changed to H2, Icon changed and styled. Note the thickness of the icon and the different shape vs. the wireframe. We're using the free icons so this is the weight and shape we have to work with. I experimented with altering the fill/stroke via css but the icon became malformed.

**Graph Title**
Title: ‘H2’, Black
Replaced ‘info’ icon with icon: ‘export-variant’
Icon color: Black
Icon button
Background color: White
Stroke: 1px, Black 20
Padding: 8px 10px 8px 10px
Border radius: 6px

**Goal**
<img width="1335" height="205" alt="Screenshot 2026-05-07 at 12 31 20 PM" src="https://github.com/user-attachments/assets/784451ec-c575-49be-8162-f7b57f4be613" />

**After**
<img width="1434" height="240" alt="Screenshot 2026-05-07 at 12 32 17 PM" src="https://github.com/user-attachments/assets/69a7f4ce-a068-4907-b320-9c76b9239583" />

**Before**
<img width="1434" height="240" alt="Screenshot 2026-05-07 at 12 31 43 PM" src="https://github.com/user-attachments/assets/a06ca81e-3ab8-4fc6-9b14-c26b239b80c9" />

