### PR TITLE
Map key changed to Recent Data and Out of Date

### DIFF
--- a/src/Features/ERDDAP/Map/index.tsx
+++ b/src/Features/ERDDAP/Map/index.tsx
@@ -123,7 +123,7 @@ const LegendItem = ({ active }: { active: boolean }) => {
   return (
     <span className="caption d-flex flex-row align-items-center">
       <div className={`erddap-key-dot ${active ? "erddap-dot-active" : "erddap-dot-inactive"}`}></div>
-      {active ? "< 24 hours" : "> 24 hours"}
+      {active ? "Recent Data" : "Out of Date"}
     </span>
   )
 }
@@ -132,7 +132,6 @@ const LegendItem = ({ active }: { active: boolean }) => {
 const MapLegend = () => {
   return (
     <div className="map-key d-flex flex-column gap-1 bg-white border rounded-1 py-2 px-3">
-      <p className="caption m-0">Recent Data</p>
       <LegendItem active={true} />
       <LegendItem active={false} />
     </div>

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -34,7 +34,7 @@ test.describe("Platform A01", () => {
     await expect(page.getByText("Loading").first()).toBeHidden()
 
     const cards = await page.locator(".card")
-    await expect(await cards.count()).toBeGreaterThan(2)
+    await expect(await cards.count()).toBeGreaterThan(4)
   })
 
   test("Shows air temp plot", async ({ page }) => {

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -34,7 +34,7 @@ test.describe("Platform A01", () => {
     await expect(page.getByText("Loading").first()).toBeHidden()
 
     const cards = await page.locator(".card")
-    await expect(await cards.count()).toBeGreaterThan(4)
+    await expect(await cards.count()).toBeGreaterThan(2)
   })
 
   test("Shows air temp plot", async ({ page }) => {


### PR DESCRIPTION
@cgalvarino 

Quick change to the map key prompted by the Slack conversation.

**Before**
<img width="141" height="108" alt="Screenshot 2026-05-13 at 11 17 33 AM" src="https://github.com/user-attachments/assets/ffebd2a9-14d8-44c0-bdef-439e6c32b3e8" />

**After**
<img width="155" height="98" alt="Screenshot 2026-05-13 at 11 16 34 AM" src="https://github.com/user-attachments/assets/6f7e74a1-f28e-45aa-9522-5eb690168303" />

I did have a playwright change that's not related to the map key, for the life of me I couldn't figure out what was different between dev main and this branch, both of which looked just like prod in the context of what was being tested. Tested main on playwright and the same test failed, so something must've slipped through? Just wanted to highlight this in case you all thought I was pulling a fast one by not mentioning it.