### PR TITLE
Large graph quick timeframe selectors

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/Condition/Info.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/Info.tsx
@@ -65,7 +65,7 @@ export const Info: React.FC<InfoProps> = ({ timeSeries, id, startDate }: InfoPro
   return (
     <React.Fragment>
       <OverlayTrigger delay={{ show: 250, hide: 4000 }} overlay={renderToolTip} trigger={["click"]}>
-        <ExportIcon id={`tooltip-${id}-trigger`} className="export-icon-border bg-white p-1" />
+        <ExportIcon id={`tooltip-${id}-trigger`} className="export-icon-border bg-white p-1" role="button" />
       </OverlayTrigger>
     </React.Fragment>
   )

--- a/src/Features/ERDDAP/Platform/Observations/Condition/Info.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/Info.tsx
@@ -1,5 +1,3 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons"
 import React from "react"
 import OverlayTrigger from "react-bootstrap/OverlayTrigger"
 import Popover from "react-bootstrap/Popover"

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -8,11 +8,11 @@ import { PlatformLoadingAlert } from "components/Alerts"
 import { LargeTimeSeriesChart } from "components/Charts/LargeTimeSeries"
 import { UnitSystem } from "Features/Units/types"
 import { useUnitSystem } from "Features/Units"
-import { TimeframeSelector } from "Features/ERDDAP/TimeframeSelector"
+import { TimeframePicker } from "Features/ERDDAP/TimeframeSelector/TimeframePicker"
 import { TimeframeButtonGroup, TimeframeDropdown } from "Features/ERDDAP/TimeframeButtonGroup"
 import { naturalBounds } from "Shared/dataTypes"
 import { DataTimeSeries } from "Shared/timeSeries"
-import { aWeekAgoRounded, daysInFuture, manuallySetFullEODIso } from "Shared/time"
+import { aWeekAgoRounded, daysInFuture } from "Shared/time"
 
 import { UseDataset } from "../../../hooks"
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
@@ -33,18 +33,11 @@ interface Props {
  */
 export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platform, standardName }: Props) => {
   const unitSystem = useUnitSystem()
-  const searchParams = useSearchParams()
-  const [startDate, setStartDate] = useState(
-    searchParams.get("start") ? new Date(searchParams.get("start") as string) : aWeekAgoRounded(),
-  )
-  const [endDate, setEndDate] = useState(
-    searchParams.get("end") ? manuallySetFullEODIso(new Date(searchParams.get("end") as string)) : daysInFuture(0),
-  )
+  const [startDate, setStartDate] = useState(aWeekAgoRounded())
+  const [endDate, setEndDate] = useState(daysInFuture(0))
 
   // Keep a timeframe to allow "unsetting" of the toggle
-  const [timeFrame, setTimeFrame] = useState<Timeframes>(() =>
-    searchParams.get("start") || searchParams.get("end") ? "custom" : "7d",
-  )
+  const [timeFrame, setTimeFrame] = useState<Timeframes>("7d")
   const handleTimeframeChange = (val: Timeframes) => {
     if (val === null) return // No val no set
     setTimeFrame(val)
@@ -52,6 +45,9 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
     setStartDate(start)
     setEndDate(daysInFuture(0))
   }
+
+  const handleStartChoice = (start: Date) => setStartDate(start)
+  const handleEndChoice = (end: Date) => setEndDate(end)
 
   const timeSeries: PlatformTimeSeries[] = platform.properties.readings.filter(
     (reading) => reading.data_type.standard_name === standardName,
@@ -75,7 +71,15 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
             className="order-2 order-md-1"
           />
           <div className="flex-row ms-auto order-1 order-md-2">
-            {index === 0 && timeFrame === "custom" && <TimeframeSelector graphFuture={false} />}
+            {index === 0 && timeFrame === "custom" && (
+              <TimeframePicker
+                start={startDate}
+                end={endDate}
+                handleStart={handleStartChoice}
+                handleEnd={handleEndChoice}
+                graphFuture={false}
+              />
+            )}
           </div>
         </div>
 

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -15,8 +15,9 @@ import { DataTimeSeries } from "Shared/timeSeries"
 import { aWeekAgoRounded, daysInFuture, manuallySetFullEODIso } from "Shared/time"
 
 import { UseDataset } from "../../../hooks"
-import { PlatformFeature, PlatformTimeSeries, TimeFrameRange } from "../../../types"
+import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 import { Info } from "./Info"
+import { getStartFunction, Timeframes } from "Features/ERDDAP/TimeframeButtonGroup/timeframes"
 
 interface Props {
   /** Platform to display */
@@ -39,9 +40,15 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
   const [endDate, setEndDate] = useState(
     searchParams.get("end") ? manuallySetFullEODIso(new Date(searchParams.get("end") as string)) : daysInFuture(0),
   )
-  const handleTimeframeChange = ({ start, end }: TimeFrameRange) => {
+
+  // Keep a timeframe to allow "unsetting" of the toggle
+  const [timeFrame, setTimeFrame] = useState<Timeframes>()
+  const handleTimeframeChange = (val: Timeframes) => {
+    if (val === null) return // No val no set
+    setTimeFrame(val)
+    const start = getStartFunction(val)
     setStartDate(start)
-    setEndDate(end)
+    setEndDate(daysInFuture(0))
   }
 
   const timeSeries: PlatformTimeSeries[] = platform.properties.readings.filter(
@@ -59,11 +66,11 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
         </h2>
         <div className="d-flex flex-column flex-md-row gap-2 align-items-center">
           <TimeframeButtonGroup
-            defaultValue="7d"
             name="time-frame-group"
             type="radio"
+            value={timeFrame ?? undefined}
+            onChange={handleTimeframeChange}
             className="order-2 order-md-1"
-            onTimeframeChange={handleTimeframeChange}
           />
           <div className="d-flex flex-row ms-auto order-1 order-md-2">
             {index === 0 && <TimeframeSelector graphFuture={false} />}

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -9,7 +9,7 @@ import { LargeTimeSeriesChart } from "components/Charts/LargeTimeSeries"
 import { UnitSystem } from "Features/Units/types"
 import { useUnitSystem } from "Features/Units"
 import { TimeframeSelector } from "Features/ERDDAP/TimeframeSelector"
-import { TimeframeButtonGroup } from "Features/ERDDAP/TimeframeButtonGroup"
+import { TimeframeButtonGroup, TimeframeDropdown } from "Features/ERDDAP/TimeframeButtonGroup"
 import { naturalBounds } from "Shared/dataTypes"
 import { DataTimeSeries } from "Shared/timeSeries"
 import { aWeekAgoRounded, daysInFuture, manuallySetFullEODIso } from "Shared/time"
@@ -42,7 +42,9 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
   )
 
   // Keep a timeframe to allow "unsetting" of the toggle
-  const [timeFrame, setTimeFrame] = useState<Timeframes>()
+  const [timeFrame, setTimeFrame] = useState<Timeframes>(() =>
+    searchParams.get("start") || searchParams.get("end") ? "custom" : "7d",
+  )
   const handleTimeframeChange = (val: Timeframes) => {
     if (val === null) return // No val no set
     setTimeFrame(val)
@@ -64,18 +66,28 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
         <h2 className="d-flex gap-2 justify-content-center align-items-center">
           {ts.data_type.long_name} {depth} <Info timeSeries={[ts]} id={index} startDate={startDate} />
         </h2>
-        <div className="d-flex flex-column flex-md-row gap-2 align-items-center">
+        <div className="d-none d-lg-flex flex-column flex-md-row gap-2 align-items-center">
           <TimeframeButtonGroup
             name="time-frame-group"
             type="radio"
-            value={timeFrame ?? undefined}
+            value={timeFrame ?? "7d"}
             onChange={handleTimeframeChange}
             className="order-2 order-md-1"
           />
-          <div className="d-flex flex-row ms-auto order-1 order-md-2">
-            {index === 0 && <TimeframeSelector graphFuture={false} />}
+          <div className="flex-row ms-auto order-1 order-md-2">
+            {index === 0 && timeFrame === "custom" && <TimeframeSelector graphFuture={false} />}
           </div>
         </div>
+
+        <div className="d-flex d-lg-none justify-content-center justify-content-md-start">
+          <TimeframeDropdown
+            id="dropdown-timeframe"
+            value={timeFrame}
+            handleChange={handleTimeframeChange}
+            className="align-items-center"
+          />
+        </div>
+
         <UseDataset
           timeSeries={ts}
           startTime={startDate}

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -58,7 +58,13 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
           {ts.data_type.long_name} {depth} <Info timeSeries={[ts]} id={index} startDate={startDate} />
         </h2>
         <div className="d-flex flex-column flex-md-row gap-2 align-items-center">
-          <TimeframeButtonGroup className="order-2 order-md-1" onTimeframeChange={handleTimeframeChange} />
+          <TimeframeButtonGroup
+            defaultValue="7d"
+            name="time-frame-group"
+            type="radio"
+            className="order-2 order-md-1"
+            onTimeframeChange={handleTimeframeChange}
+          />
           <div className="d-flex flex-row ms-auto order-1 order-md-2">
             {index === 0 && <TimeframeSelector graphFuture={false} />}
           </div>

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -9,12 +9,13 @@ import { LargeTimeSeriesChart } from "components/Charts/LargeTimeSeries"
 import { UnitSystem } from "Features/Units/types"
 import { useUnitSystem } from "Features/Units"
 import { TimeframeSelector } from "Features/ERDDAP/TimeframeSelector"
+import { TimeframeButtonGroup } from "Features/ERDDAP/TimeframeButtonGroup"
 import { naturalBounds } from "Shared/dataTypes"
 import { DataTimeSeries } from "Shared/timeSeries"
 import { aWeekAgoRounded, daysInFuture, manuallySetFullEODIso } from "Shared/time"
 
 import { UseDataset } from "../../../hooks"
-import { PlatformFeature, PlatformTimeSeries } from "../../../types"
+import { PlatformFeature, PlatformTimeSeries, TimeFrameRange } from "../../../types"
 import { Info } from "./Info"
 
 interface Props {
@@ -38,6 +39,10 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
   const [endDate, setEndDate] = useState(
     searchParams.get("end") ? manuallySetFullEODIso(new Date(searchParams.get("end") as string)) : daysInFuture(0),
   )
+  const handleTimeframeChange = ({ start, end }: TimeFrameRange) => {
+    setStartDate(start)
+    setEndDate(end)
+  }
 
   const timeSeries: PlatformTimeSeries[] = platform.properties.readings.filter(
     (reading) => reading.data_type.standard_name === standardName,
@@ -52,8 +57,9 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
         <h2 className="d-flex gap-2 justify-content-center align-items-center">
           {ts.data_type.long_name} {depth} <Info timeSeries={[ts]} id={index} startDate={startDate} />
         </h2>
-        <div>
-          <div className="observation-timeframe-selector">
+        <div className="d-flex flex-column flex-md-row gap-2 align-items-center">
+          <TimeframeButtonGroup className="order-2 order-md-1" onTimeframeChange={handleTimeframeChange} />
+          <div className="d-flex flex-row ms-auto order-1 order-md-2">
             {index === 0 && <TimeframeSelector graphFuture={false} />}
           </div>
         </div>

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -62,35 +62,39 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
         <h2 className="d-flex gap-2 justify-content-center align-items-center">
           {ts.data_type.long_name} {depth} <Info timeSeries={[ts]} id={index} startDate={startDate} />
         </h2>
-        <div className="d-none d-lg-flex flex-column flex-md-row gap-2 align-items-center">
-          <TimeframeButtonGroup
-            name="time-frame-group"
-            type="radio"
-            value={timeFrame ?? "7d"}
-            onChange={handleTimeframeChange}
-            className="order-2 order-md-1"
-          />
-          <div className="flex-row ms-auto order-1 order-md-2">
-            {index === 0 && timeFrame === "custom" && (
-              <TimeframePicker
-                start={startDate}
-                end={endDate}
-                handleStart={handleStartChoice}
-                handleEnd={handleEndChoice}
-                graphFuture={false}
-              />
-            )}
+        {index === 0 && (
+          <div className="d-none d-lg-flex flex-column flex-md-row gap-2 align-items-center">
+            <TimeframeButtonGroup
+              name="time-frame-group"
+              type="radio"
+              value={timeFrame ?? "7d"}
+              onChange={handleTimeframeChange}
+              className="order-2 order-md-1"
+            />
+            <div className="flex-row ms-auto order-1 order-md-2">
+              {timeFrame === "custom" && (
+                <TimeframePicker
+                  start={startDate}
+                  end={endDate}
+                  handleStart={handleStartChoice}
+                  handleEnd={handleEndChoice}
+                  graphFuture={false}
+                />
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
-        <div className="d-flex d-lg-none justify-content-center justify-content-md-start">
-          <TimeframeDropdown
-            id="dropdown-timeframe"
-            value={timeFrame}
-            handleChange={handleTimeframeChange}
-            className="align-items-center"
-          />
-        </div>
+        {index === 0 && (
+          <div className="d-flex d-lg-none justify-content-center justify-content-md-start">
+            <TimeframeDropdown
+              id="dropdown-timeframe"
+              value={timeFrame}
+              handleChange={handleTimeframeChange}
+              className="align-items-center"
+            />
+          </div>
+        )}
 
         <UseDataset
           timeSeries={ts}

--- a/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
@@ -55,14 +55,7 @@ export const LatestObsCard = ({ unitSystem, timeSeries, platform }: CardDisplayP
   }
 
   return (
-    <Link
-      href={urlPartReplacer(
-        urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
-        ":type",
-        firstTs.data_type.standard_name,
-      )}
-      className="d-flex text-decoration-none text-info"
-    >
+    <Link href={linkTarget} className="d-flex text-decoration-none text-info">
       <Col className="d-flex latest-obs-card">
         <Sentry.ErrorBoundary fallback={<b>Error displaying {firstTs.data_type.long_name}</b>} showDialog={false}>
           <Card className="flex-fill card-drop-shadow">

--- a/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
@@ -20,7 +20,7 @@ import { UseDatasets } from "Features/ERDDAP/hooks"
 import { TimeframeSelector } from "Features/ERDDAP/TimeframeSelector"
 import { useSearchParams } from "next/navigation"
 import { getStartFunction, Timeframes } from "Features/ERDDAP/TimeframeButtonGroup/timeframes"
-import { TimeframeButtonGroup } from "Features/ERDDAP/TimeframeButtonGroup"
+import { TimeframeButtonGroup, TimeframeDropdown } from "Features/ERDDAP/TimeframeButtonGroup"
 
 interface Props {
   platform: PlatformFeature
@@ -47,7 +47,9 @@ export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ pl
     searchParams.get("end") ? manuallySetFullEODIso(new Date(searchParams.get("end") as string)) : daysInFuture(0),
   )
 
-  const [timeFrame, setTimeFrame] = useState<Timeframes>()
+  const [timeFrame, setTimeFrame] = useState<Timeframes>(() =>
+    searchParams.get("start") || searchParams.get("end") ? "custom" : "7d",
+  )
   const handleTimeframeChange = (val: Timeframes) => {
     if (val === null) return // No val no set
     setTimeFrame(val)
@@ -67,18 +69,28 @@ export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ pl
       <h2 className="d-flex gap-2 justify-content-center align-items-center">
         Wind <Info timeSeries={timeSeries} id={0} startDate={startDate} />
       </h2>
-      <div className="d-flex flex-column flex-md-row gap-2 align-items-center">
+      <div className="d-none d-lg-flex flex-column flex-md-row gap-2 align-items-center">
         <TimeframeButtonGroup
           name="time-frame-group"
           type="radio"
-          value={timeFrame ?? undefined}
+          value={timeFrame ?? "7d"}
           onChange={handleTimeframeChange}
           className="order-2 order-md-1"
         />
-        <div className="d-flex flex-row ms-auto order-1 order-md-2">
-          <TimeframeSelector graphFuture={false} />
+        <div className="flex-row ms-auto order-1 order-md-2">
+          {timeFrame === "custom" && <TimeframeSelector graphFuture={false} />}
         </div>
       </div>
+
+      <div className="d-flex d-lg-none justify-content-center">
+        <TimeframeDropdown
+          id="dropdown-timeframe"
+          value={timeFrame}
+          handleChange={handleTimeframeChange}
+          className="align-items-center"
+        />
+      </div>
+
       <UseDatasets timeSeries={timeSeries} startTime={startDate} endTime={endDate} platformId={platform.id}>
         {({ datasets }) => (
           <ErddapWindObservedConditionDisplay {...{ platform, unitSystem, timeSeries, datasets, startDate, endDate }} />

--- a/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
@@ -4,6 +4,7 @@
 import React from "react"
 import Col from "react-bootstrap/Col"
 import Row from "react-bootstrap/Row"
+import { useState } from "react"
 
 import { WarningAlert } from "components/Alerts"
 import { WindTimeSeriesChart } from "components/Charts"
@@ -18,6 +19,8 @@ import { Info } from "../Condition/Info"
 import { UseDatasets } from "Features/ERDDAP/hooks"
 import { TimeframeSelector } from "Features/ERDDAP/TimeframeSelector"
 import { useSearchParams } from "next/navigation"
+import { getStartFunction, Timeframes } from "Features/ERDDAP/TimeframeButtonGroup/timeframes"
+import { TimeframeButtonGroup } from "Features/ERDDAP/TimeframeButtonGroup"
 
 interface Props {
   platform: PlatformFeature
@@ -37,10 +40,21 @@ interface DisplayProps extends Props {
 export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ platform }: Props) => {
   const unitSystem = useUnitSystem()
   const searchParams = useSearchParams()
-  const startDate = searchParams.get("start") ? new Date(searchParams.get("start") as string) : aWeekAgoRounded()
-  const endDate = searchParams.get("end")
-    ? manuallySetFullEODIso(new Date(searchParams.get("end") as string))
-    : daysInFuture(0)
+  const [startDate, setStartDate] = useState(
+    searchParams.get("start") ? new Date(searchParams.get("start") as string) : aWeekAgoRounded(),
+  )
+  const [endDate, setEndDate] = useState(
+    searchParams.get("end") ? manuallySetFullEODIso(new Date(searchParams.get("end") as string)) : daysInFuture(0),
+  )
+
+  const [timeFrame, setTimeFrame] = useState<Timeframes>()
+  const handleTimeframeChange = (val: Timeframes) => {
+    if (val === null) return // No val no set
+    setTimeFrame(val)
+    const start = getStartFunction(val)
+    setStartDate(start)
+    setEndDate(daysInFuture(0))
+  }
 
   const { timeSeries } = pickWindTimeSeries(platform)
 
@@ -49,11 +63,28 @@ export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ pl
   }
 
   return (
-    <UseDatasets timeSeries={timeSeries} startTime={startDate} endTime={endDate} platformId={platform.id}>
-      {({ datasets }) => (
-        <ErddapWindObservedConditionDisplay {...{ platform, unitSystem, timeSeries, datasets, startDate, endDate }} />
-      )}
-    </UseDatasets>
+    <div>
+      <h2 className="d-flex gap-2 justify-content-center align-items-center">
+        Wind <Info timeSeries={timeSeries} id={0} startDate={startDate} />
+      </h2>
+      <div className="d-flex flex-column flex-md-row gap-2 align-items-center">
+        <TimeframeButtonGroup
+          name="time-frame-group"
+          type="radio"
+          value={timeFrame ?? undefined}
+          onChange={handleTimeframeChange}
+          className="order-2 order-md-1"
+        />
+        <div className="d-flex flex-row ms-auto order-1 order-md-2">
+          <TimeframeSelector graphFuture={false} />
+        </div>
+      </div>
+      <UseDatasets timeSeries={timeSeries} startTime={startDate} endTime={endDate} platformId={platform.id}>
+        {({ datasets }) => (
+          <ErddapWindObservedConditionDisplay {...{ platform, unitSystem, timeSeries, datasets, startDate, endDate }} />
+        )}
+      </UseDatasets>
+    </div>
   )
 }
 
@@ -71,21 +102,13 @@ export const ErddapWindObservedConditionDisplay: React.FunctionComponent<Display
   const { speed, gust, direction } = pickWindDatasets(platform, datasets)
 
   return (
-    <div>
-      <h2 className="d-flex gap-2 justify-content-center align-items-center">
-        Wind <Info timeSeries={timeSeries} id={0} startDate={startDate} />
-      </h2>
-      <div className="observation-timeframe-selector">
-        <TimeframeSelector graphFuture={false} />
-      </div>
-      <WindTimeSeriesChart
-        barbsPerDay={5}
-        legend={true}
-        {...{ speed, gust, direction, unitSystem }}
-        startTime={startDate}
-        endTime={endDate}
-      />
-    </div>
+    <WindTimeSeriesChart
+      barbsPerDay={5}
+      legend={true}
+      {...{ speed, gust, direction, unitSystem }}
+      startTime={startDate}
+      endTime={endDate}
+    />
   )
 }
 

--- a/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WindCondition/index.tsx
@@ -17,7 +17,7 @@ import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 import { pickWindDatasets, pickWindTimeSeries } from "../../../utils/wind"
 import { Info } from "../Condition/Info"
 import { UseDatasets } from "Features/ERDDAP/hooks"
-import { TimeframeSelector } from "Features/ERDDAP/TimeframeSelector"
+import { TimeframePicker } from "Features/ERDDAP/TimeframeSelector/TimeframePicker"
 import { useSearchParams } from "next/navigation"
 import { getStartFunction, Timeframes } from "Features/ERDDAP/TimeframeButtonGroup/timeframes"
 import { TimeframeButtonGroup, TimeframeDropdown } from "Features/ERDDAP/TimeframeButtonGroup"
@@ -39,17 +39,11 @@ interface DisplayProps extends Props {
  */
 export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ platform }: Props) => {
   const unitSystem = useUnitSystem()
-  const searchParams = useSearchParams()
-  const [startDate, setStartDate] = useState(
-    searchParams.get("start") ? new Date(searchParams.get("start") as string) : aWeekAgoRounded(),
-  )
-  const [endDate, setEndDate] = useState(
-    searchParams.get("end") ? manuallySetFullEODIso(new Date(searchParams.get("end") as string)) : daysInFuture(0),
-  )
+  const [startDate, setStartDate] = useState(aWeekAgoRounded())
+  const [endDate, setEndDate] = useState(daysInFuture(0))
 
-  const [timeFrame, setTimeFrame] = useState<Timeframes>(() =>
-    searchParams.get("start") || searchParams.get("end") ? "custom" : "7d",
-  )
+  const [timeFrame, setTimeFrame] = useState<Timeframes>("7d")
+  // State handlers for the presets and the time picker
   const handleTimeframeChange = (val: Timeframes) => {
     if (val === null) return // No val no set
     setTimeFrame(val)
@@ -57,6 +51,8 @@ export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ pl
     setStartDate(start)
     setEndDate(daysInFuture(0))
   }
+  const handleStartChoice = (start: Date) => setStartDate(start)
+  const handleEndChoice = (end: Date) => setEndDate(end)
 
   const { timeSeries } = pickWindTimeSeries(platform)
 
@@ -78,7 +74,15 @@ export const ErddapWindObservedCondition: React.FunctionComponent<Props> = ({ pl
           className="order-2 order-md-1"
         />
         <div className="flex-row ms-auto order-1 order-md-2">
-          {timeFrame === "custom" && <TimeframeSelector graphFuture={false} />}
+          {timeFrame === "custom" && (
+            <TimeframePicker
+              start={startDate}
+              end={endDate}
+              handleStart={handleStartChoice}
+              handleEnd={handleEndChoice}
+              graphFuture={false}
+            />
+          )}
         </div>
       </div>
 

--- a/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
+++ b/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
@@ -1,8 +1,20 @@
-import { ToggleButtonGroup, ToggleButton, ToggleButtonGroupProps } from "react-bootstrap"
+import {
+  ToggleButtonGroup,
+  ToggleButton,
+  Dropdown,
+  DropdownButton,
+  DropdownButtonProps,
+  ToggleButtonGroupProps,
+} from "react-bootstrap"
 
-import { Timeframes, possibleTimeframes } from "./timeframes"
+import { Timeframes, possibleTimeframes, getPresetLabel } from "./timeframes"
 
 type TimeframeToggleGroupProps = ToggleButtonGroupProps<Timeframes> & {}
+type TimeframeDropdownProps = Omit<DropdownButtonProps, "children" | "title"> & {
+  id: string
+  value: Timeframes
+  handleChange: (val: Timeframes) => void
+}
 
 export const TimeframeButtonGroup = ({ ...props }: TimeframeToggleGroupProps) => {
   return (
@@ -18,6 +30,28 @@ export const TimeframeButtonGroup = ({ ...props }: TimeframeToggleGroupProps) =>
           {label}
         </ToggleButton>
       ))}
+      <ToggleButton id="timeframe-custom" value="custom" variant="light" className="border text-black-20">
+        Custom...
+      </ToggleButton>
     </ToggleButtonGroup>
+  )
+}
+
+export const TimeframeDropdown = ({ id, value, handleChange, ...props }: TimeframeDropdownProps) => {
+  return (
+    <DropdownButton
+      id={id}
+      title={getPresetLabel(value)}
+      variant="light"
+      // When selecting a dropdown change the timeframe
+      onSelect={(key) => key && handleChange(key as Timeframes)}
+      {...props}
+    >
+      {possibleTimeframes.map(({ label, value }) => (
+        <Dropdown.Item key={value} eventKey={value}>
+          {label}
+        </Dropdown.Item>
+      ))}
+    </DropdownButton>
   )
 }

--- a/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
+++ b/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
@@ -1,54 +1,23 @@
-import { ToggleButtonGroup, ToggleButton, ToggleButtonGroupProps, ToggleButtonProps } from "react-bootstrap"
+import { ToggleButtonGroup, ToggleButton, ToggleButtonGroupProps } from "react-bootstrap"
 
-import { calcAnyHourAgoRounded, daysAgoRounded, daysInFuture } from "Shared/time"
+import { Timeframes, possibleTimeframes } from "./timeframes"
 
-import { TimeFrameRange } from "../types"
+type TimeframeToggleGroupProps = ToggleButtonGroupProps<Timeframes> & {}
 
-type Timeframes = "24h" | "7d" | "30d"
-type TimeframeToggleGroupProps = ToggleButtonGroupProps<Timeframes> & {
-  onTimeframeChange: (range: TimeFrameRange) => void
-}
-type TimeframeToggleProps = ToggleButtonProps & {
-  handlePresetDates: (start: Date) => void
-  start: Date
-}
-
-const TimeframeButton = ({ start, handlePresetDates, children, ...props }: TimeframeToggleProps) => {
-  return (
-    <ToggleButton
-      onClick={() => {
-        handlePresetDates(start)
-      }}
-      variant="light"
-      className="border text-black-20"
-      {...props}
-    >
-      {children}
-    </ToggleButton>
-  )
-}
-
-export const TimeframeButtonGroup = ({ onTimeframeChange, ...props }: TimeframeToggleGroupProps) => {
-  const handlePresetDates = (start: Date) => {
-    onTimeframeChange({ start, end: daysInFuture(0) })
-  }
-
+export const TimeframeButtonGroup = ({ ...props }: TimeframeToggleGroupProps) => {
   return (
     <ToggleButtonGroup {...props}>
-      <TimeframeButton
-        id="timeframe-24h"
-        value="24h"
-        start={calcAnyHourAgoRounded(24)}
-        handlePresetDates={handlePresetDates}
-      >
-        Last 24 hours
-      </TimeframeButton>
-      <TimeframeButton id="timeframe-7d" value="7d" start={daysAgoRounded(7)} handlePresetDates={handlePresetDates}>
-        Last 7 days
-      </TimeframeButton>
-      <TimeframeButton id="timeframe-30d" value="30d" start={daysAgoRounded(30)} handlePresetDates={handlePresetDates}>
-        Last 30 days
-      </TimeframeButton>
+      {possibleTimeframes.map(({ label, value }) => (
+        <ToggleButton
+          key={value}
+          id={`timeframe-${value}`}
+          value={value}
+          variant="light"
+          className="border text-black-20"
+        >
+          {label}
+        </ToggleButton>
+      ))}
     </ToggleButtonGroup>
   )
 }

--- a/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
+++ b/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
@@ -1,0 +1,47 @@
+import { Button, ButtonGroup, ButtonGroupProps, ButtonProps } from "react-bootstrap"
+
+import { calcAnyHourAgoRounded, daysAgoRounded, daysInFuture } from "Shared/time"
+
+import { TimeFrameRange } from "../types"
+
+type TimeframeButtonGroupProps = ButtonGroupProps & {
+  onTimeframeChange: (range: TimeFrameRange) => void
+}
+type TimeframeButtonProps = ButtonProps & {
+  handlePresetDates: (start: Date) => void
+  start: Date
+}
+
+const TimeframeButton = ({ start, handlePresetDates, children, ...props }: TimeframeButtonProps) => {
+  return (
+    <Button
+      onClick={() => {
+        handlePresetDates(start)
+      }}
+      variant="light"
+      {...props}
+    >
+      {children}
+    </Button>
+  )
+}
+
+export const TimeframeButtonGroup = ({ onTimeframeChange, ...props }: TimeframeButtonGroupProps) => {
+  const handlePresetDates = (start: Date) => {
+    onTimeframeChange({ start, end: daysInFuture(0) })
+  }
+
+  return (
+    <ButtonGroup {...props}>
+      <TimeframeButton start={calcAnyHourAgoRounded(24)} handlePresetDates={handlePresetDates}>
+        Last 24 hours
+      </TimeframeButton>
+      <TimeframeButton start={daysAgoRounded(7)} handlePresetDates={handlePresetDates}>
+        Last 7 days
+      </TimeframeButton>
+      <TimeframeButton start={daysAgoRounded(30)} handlePresetDates={handlePresetDates}>
+        Last 30 days
+      </TimeframeButton>
+    </ButtonGroup>
+  )
+}

--- a/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
+++ b/src/Features/ERDDAP/TimeframeButtonGroup/index.tsx
@@ -1,47 +1,54 @@
-import { Button, ButtonGroup, ButtonGroupProps, ButtonProps } from "react-bootstrap"
+import { ToggleButtonGroup, ToggleButton, ToggleButtonGroupProps, ToggleButtonProps } from "react-bootstrap"
 
 import { calcAnyHourAgoRounded, daysAgoRounded, daysInFuture } from "Shared/time"
 
 import { TimeFrameRange } from "../types"
 
-type TimeframeButtonGroupProps = ButtonGroupProps & {
+type Timeframes = "24h" | "7d" | "30d"
+type TimeframeToggleGroupProps = ToggleButtonGroupProps<Timeframes> & {
   onTimeframeChange: (range: TimeFrameRange) => void
 }
-type TimeframeButtonProps = ButtonProps & {
+type TimeframeToggleProps = ToggleButtonProps & {
   handlePresetDates: (start: Date) => void
   start: Date
 }
 
-const TimeframeButton = ({ start, handlePresetDates, children, ...props }: TimeframeButtonProps) => {
+const TimeframeButton = ({ start, handlePresetDates, children, ...props }: TimeframeToggleProps) => {
   return (
-    <Button
+    <ToggleButton
       onClick={() => {
         handlePresetDates(start)
       }}
       variant="light"
+      className="border text-black-20"
       {...props}
     >
       {children}
-    </Button>
+    </ToggleButton>
   )
 }
 
-export const TimeframeButtonGroup = ({ onTimeframeChange, ...props }: TimeframeButtonGroupProps) => {
+export const TimeframeButtonGroup = ({ onTimeframeChange, ...props }: TimeframeToggleGroupProps) => {
   const handlePresetDates = (start: Date) => {
     onTimeframeChange({ start, end: daysInFuture(0) })
   }
 
   return (
-    <ButtonGroup {...props}>
-      <TimeframeButton start={calcAnyHourAgoRounded(24)} handlePresetDates={handlePresetDates}>
+    <ToggleButtonGroup {...props}>
+      <TimeframeButton
+        id="timeframe-24h"
+        value="24h"
+        start={calcAnyHourAgoRounded(24)}
+        handlePresetDates={handlePresetDates}
+      >
         Last 24 hours
       </TimeframeButton>
-      <TimeframeButton start={daysAgoRounded(7)} handlePresetDates={handlePresetDates}>
+      <TimeframeButton id="timeframe-7d" value="7d" start={daysAgoRounded(7)} handlePresetDates={handlePresetDates}>
         Last 7 days
       </TimeframeButton>
-      <TimeframeButton start={daysAgoRounded(30)} handlePresetDates={handlePresetDates}>
+      <TimeframeButton id="timeframe-30d" value="30d" start={daysAgoRounded(30)} handlePresetDates={handlePresetDates}>
         Last 30 days
       </TimeframeButton>
-    </ButtonGroup>
+    </ToggleButtonGroup>
   )
 }

--- a/src/Features/ERDDAP/TimeframeButtonGroup/timeframes.ts
+++ b/src/Features/ERDDAP/TimeframeButtonGroup/timeframes.ts
@@ -1,6 +1,6 @@
 import { calcAnyHourAgoRounded, daysAgoRounded } from "Shared/time"
 
-export type Timeframes = "24h" | "7d" | "30d"
+export type Timeframes = "24h" | "7d" | "30d" | "custom"
 // An array of preset values
 type TimeFrame = { label: string; value: Timeframes; start: () => Date }[]
 
@@ -12,4 +12,9 @@ export const possibleTimeframes = [
 
 export const getStartFunction = (val: string) => {
   return val === "24h" ? calcAnyHourAgoRounded(24) : val === "7d" ? daysAgoRounded(7) : daysAgoRounded(30)
+}
+
+export const getPresetLabel = (value: Timeframes) => {
+  let label = possibleTimeframes.find((timeframe) => timeframe.value === value)?.label
+  return label ? label : "Timeframes"
 }

--- a/src/Features/ERDDAP/TimeframeButtonGroup/timeframes.ts
+++ b/src/Features/ERDDAP/TimeframeButtonGroup/timeframes.ts
@@ -11,7 +11,7 @@ export const possibleTimeframes = [
 ] satisfies TimeFrame // Satisfies helps ensure that values are limited to the contract
 
 export const getStartFunction = (val: string) => {
-  return val === "24h" ? calcAnyHourAgoRounded(24) : val === "7d" ? daysAgoRounded(7) : daysAgoRounded(30)
+  return val === "24h" ? calcAnyHourAgoRounded(24) : val === "30d" ? daysAgoRounded(30) : daysAgoRounded(7)
 }
 
 export const getPresetLabel = (value: Timeframes) => {

--- a/src/Features/ERDDAP/TimeframeButtonGroup/timeframes.ts
+++ b/src/Features/ERDDAP/TimeframeButtonGroup/timeframes.ts
@@ -1,0 +1,15 @@
+import { calcAnyHourAgoRounded, daysAgoRounded } from "Shared/time"
+
+export type Timeframes = "24h" | "7d" | "30d"
+// An array of preset values
+type TimeFrame = { label: string; value: Timeframes; start: () => Date }[]
+
+export const possibleTimeframes = [
+  { label: "Last 24 hours", value: "24h", start: () => calcAnyHourAgoRounded(24) },
+  { label: "Last 7 days", value: "7d", start: () => daysAgoRounded(7) },
+  { label: "Last 30 days", value: "30d", start: () => daysAgoRounded(30) },
+] satisfies TimeFrame // Satisfies helps ensure that values are limited to the contract
+
+export const getStartFunction = (val: string) => {
+  return val === "24h" ? calcAnyHourAgoRounded(24) : val === "7d" ? daysAgoRounded(7) : daysAgoRounded(30)
+}

--- a/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
@@ -1,8 +1,9 @@
-import { Card, Col } from "react-bootstrap"
+import { Button, Card, Col, OverlayTrigger, Tooltip } from "react-bootstrap"
 import { useState, useEffect } from "react"
 
 import { WarningAlert } from "components/Alerts"
-import { formatDate, getToday, YEAR } from "Shared/time"
+import { daysAgoRounded, daysInFuture, formatDate, getToday, YEAR } from "Shared/time"
+import { Revert } from "Shared/icons/Revert"
 
 type TimeframePickerProps = {
   start: Date
@@ -60,6 +61,17 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
               />
             </label>
           </div>
+          <OverlayTrigger overlay={<Tooltip>Revert to default date</Tooltip>}>
+            <Button
+              onClick={() => {
+                handleStart(daysAgoRounded(7))
+                handleEnd(daysInFuture(0))
+              }}
+              className="bg-info"
+            >
+              <Revert fill="#FFFFFF" />
+            </Button>
+          </OverlayTrigger>
         </Col>
       </div>
     </Card>

--- a/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
@@ -15,6 +15,9 @@ type TimeframePickerProps = {
 
 export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEnd }: TimeframePickerProps) => {
   const [validDateMessage, setValidDateMessage] = useState<string>("")
+  const [inputStart, setInputStart] = useState<Date>(start)
+  const [inputEnd, setInputEnd] = useState<Date>(end)
+
   useEffect(() => {
     const validateTimeframe = (start, end) => {
       if ((new Date(end).getTime() - new Date(start).getTime()) / YEAR > 1) {
@@ -41,22 +44,22 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
                 id="start"
                 name="start"
                 max={getToday()}
-                value={formatDate(start)}
-                onInput={(e) => handleStart(new Date((e.target as HTMLInputElement).value))}
+                value={formatDate(inputStart)}
+                onInput={(e) => setInputStart(new Date((e.target as HTMLInputElement).value))}
                 required={true}
               />
             </label>
 
             <label className="d-flex align-items-center">
-              <p style={{ marginBottom: 0, marginRight: "5px" }}>End:</p>
+              <p className="mb-0 pe-1">End:</p>
               <input
                 type="date"
                 id="end"
                 name="end"
                 min={formatDate(start)}
                 max={graphFuture ? undefined : getToday()}
-                value={formatDate(end)}
-                onInput={(e) => handleEnd(new Date((e.target as HTMLInputElement).value))}
+                value={formatDate(inputEnd)}
+                onInput={(e) => setInputEnd(new Date((e.target as HTMLInputElement).value))}
                 required={true}
               />
             </label>
@@ -64,12 +67,33 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
           <OverlayTrigger overlay={<Tooltip>Revert to default date</Tooltip>}>
             <Button
               onClick={() => {
-                handleStart(daysAgoRounded(7))
-                handleEnd(daysInFuture(0))
+                const revertStart = daysAgoRounded(7)
+                const revertEnd = daysInFuture(0)
+
+                setInputStart(revertStart)
+                setInputEnd(revertEnd)
+                handleStart(revertStart)
+                handleEnd(revertEnd)
               }}
               className="bg-info"
             >
               <Revert fill="#FFFFFF" />
+            </Button>
+          </OverlayTrigger>
+          <OverlayTrigger
+            overlay={(props) => {
+              return validDateMessage !== "" ? <Tooltip {...props}>{validDateMessage}</Tooltip> : <span />
+            }}
+          >
+            <Button
+              onClick={() => {
+                handleStart(inputStart)
+                handleEnd(inputEnd)
+              }}
+              disabled={!inputStart || !inputEnd || validDateMessage !== ""}
+              className="bg-info"
+            >
+              Plot
             </Button>
           </OverlayTrigger>
         </Col>

--- a/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
@@ -15,6 +15,7 @@ type TimeframePickerProps = {
 
 export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEnd }: TimeframePickerProps) => {
   const [validDateMessage, setValidDateMessage] = useState<string>("")
+  const [invalidInput, setInvalidInput] = useState<Boolean>(false)
   const [inputStart, setInputStart] = useState<Date>(start)
   const [inputEnd, setInputEnd] = useState<Date>(end)
 
@@ -26,10 +27,11 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
       if (new Date(end).getTime() - new Date(start).getTime() < 0) {
         return "Please choose a date where the start is before the end"
       }
+      setInvalidInput(false)
       return ""
     }
     setValidDateMessage(validateTimeframe(inputStart, inputEnd))
-  }, [start, end])
+  }, [inputStart, inputEnd])
 
   return (
     <Card className="p-2">
@@ -89,12 +91,13 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
               onClick={() => {
                 if ((new Date(inputEnd).getTime() - new Date(inputStart).getTime()) / YEAR > 1) {
                   setValidDateMessage("Please choose a timeframe that spans less than one year")
+                  setInvalidInput(true)
                   return
                 }
                 handleStart(inputStart)
                 handleEnd(inputEnd)
               }}
-              disabled={!inputStart || !inputEnd || validDateMessage !== ""}
+              disabled={!inputStart || !inputEnd}
               className="bg-info"
             >
               Plot

--- a/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
@@ -56,7 +56,7 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
                 type="date"
                 id="end"
                 name="end"
-                min={formatDate(start)}
+                min={formatDate(inputStart)}
                 max={graphFuture ? undefined : getToday()}
                 value={formatDate(inputEnd)}
                 onInput={(e) => setInputEnd(new Date((e.target as HTMLInputElement).value))}

--- a/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
@@ -28,7 +28,7 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
       }
       return ""
     }
-    setValidDateMessage(validateTimeframe(start, end))
+    setValidDateMessage(validateTimeframe(inputStart, inputEnd))
   }, [start, end])
 
   return (
@@ -87,6 +87,10 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
           >
             <Button
               onClick={() => {
+                if ((new Date(inputEnd).getTime() - new Date(inputStart).getTime()) / YEAR > 1) {
+                  setValidDateMessage("Please choose a timeframe that spans less than one year")
+                  return
+                }
                 handleStart(inputStart)
                 handleEnd(inputEnd)
               }}

--- a/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
@@ -1,0 +1,67 @@
+import { Card, Col } from "react-bootstrap"
+import { useState, useEffect } from "react"
+
+import { WarningAlert } from "components/Alerts"
+import { formatDate, getToday, YEAR } from "Shared/time"
+
+type TimeframePickerProps = {
+  start: Date
+  end: Date
+  handleStart: (start: Date) => void
+  handleEnd: (end: Date) => void
+  graphFuture: boolean
+}
+
+export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEnd }: TimeframePickerProps) => {
+  const [validDateMessage, setValidDateMessage] = useState<string>("")
+  useEffect(() => {
+    const validateTimeframe = (start, end) => {
+      if ((new Date(end).getTime() - new Date(start).getTime()) / YEAR > 1) {
+        return "Please choose a timeframe that spans less than one year"
+      }
+      if (new Date(end).getTime() - new Date(start).getTime() < 0) {
+        return "Please choose a date where the start is before the end"
+      }
+      return ""
+    }
+    setValidDateMessage(validateTimeframe(start, end))
+  }, [start, end])
+
+  return (
+    <Card className="p-2">
+      {validDateMessage !== "" && <WarningAlert>{validDateMessage}</WarningAlert>}
+      <div>
+        <Col className="gap-2 w-100 d-flex flex-row align-items-center justify-content-around">
+          <div className="d-flex flex-column flex-lg-row align-items-lg-center align-items-end gap-2">
+            <label className="d-flex align-items-center">
+              <p className="mb-0 me-1">Start:</p>
+              <input
+                type="date"
+                id="start"
+                name="start"
+                max={getToday()}
+                value={formatDate(start)}
+                onInput={(e) => handleStart(new Date((e.target as HTMLInputElement).value))}
+                required={true}
+              />
+            </label>
+
+            <label className="d-flex align-items-center">
+              <p style={{ marginBottom: 0, marginRight: "5px" }}>End:</p>
+              <input
+                type="date"
+                id="end"
+                name="end"
+                min={formatDate(start)}
+                max={graphFuture ? undefined : getToday()}
+                value={formatDate(end)}
+                onInput={(e) => handleEnd(new Date((e.target as HTMLInputElement).value))}
+                required={true}
+              />
+            </label>
+          </div>
+        </Col>
+      </div>
+    </Card>
+  )
+}

--- a/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/TimeframePicker.tsx
@@ -43,7 +43,7 @@ export const TimeframePicker = ({ start, end, graphFuture, handleStart, handleEn
                 type="date"
                 id="start"
                 name="start"
-                max={getToday()}
+                max={formatDate(inputEnd)}
                 value={formatDate(inputStart)}
                 onInput={(e) => setInputStart(new Date((e.target as HTMLInputElement).value))}
                 required={true}

--- a/src/Features/ERDDAP/TimeframeSelector/index.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/index.tsx
@@ -141,6 +141,7 @@ export function TimeframeSelector({
                   ),
                 }}
                 style={{ color: "white", textDecoration: "none", width: "100%", height: "100%" }}
+                onClick={window.location.reload}
               >
                 Plot Dates
               </Link>

--- a/src/Features/ERDDAP/TimeframeSelector/index.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/index.tsx
@@ -64,7 +64,7 @@ export function TimeframeSelector({
   }, [searchParams, isWaterLevel, graphFuture, pathname, setEndTime, setStartTime])
 
   return (
-    <Card className={`${isWaterLevel ? "timeframe-card" : "timeframe-card main"}`}>
+    <Card className={`${isWaterLevel ? "timeframe-card-wl" : "p-2"}`}>
       {validDateMessage !== "" && <WarningAlert>{validDateMessage}</WarningAlert>}
       <div>
         <Col

--- a/src/Features/ERDDAP/TimeframeSelector/index.tsx
+++ b/src/Features/ERDDAP/TimeframeSelector/index.tsx
@@ -67,45 +67,37 @@ export function TimeframeSelector({
     <Card className={`${isWaterLevel ? "timeframe-card-wl" : "p-2"}`}>
       {validDateMessage !== "" && <WarningAlert>{validDateMessage}</WarningAlert>}
       <div>
-        <Col
-          style={{
-            margin: 0,
-            padding: 0,
-            width: "100%",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "start",
-            flexWrap: "wrap",
-            gap: "8px",
-          }}
-        >
-          <label style={{ marginRight: "20px", display: "flex", alignItems: "center" }} className="timeframe-label">
-            <p style={{ marginBottom: 0, marginRight: "5px" }}>Start:</p>
-            <input
-              type="date"
-              id="start"
-              name="start"
-              max={getToday()}
-              value={formatDate(startTime)}
-              onInput={(e) => setStartTime((e.target as HTMLInputElement).value)}
-              required={true}
-            />
-          </label>
-          <label style={{ marginRight: "20px", display: "flex", alignItems: "center" }} className="timeframe-label">
-            <p style={{ marginBottom: 0, marginRight: "5px" }}>End:</p>
-            <input
-              type="date"
-              id="end"
-              name="end"
-              min={formatDate(startTime)}
-              max={graphFuture ? undefined : getToday()}
-              value={formatDate(endTime)}
-              onInput={(e) => setEndTime(formatDate(new Date((e.target as HTMLInputElement).value)))}
-              required={true}
-            />
-          </label>
+        <Col className="gap-2 w-100 d-flex flex-row align-items-center justify-content-around">
+          <div className="d-flex flex-column flex-lg-row align-items-lg-center align-items-end gap-2">
+            <label className="d-flex align-items-center">
+              <p style={{ marginBottom: 0, marginRight: "5px" }}>Start:</p>
+              <input
+                type="date"
+                id="start"
+                name="start"
+                max={getToday()}
+                value={formatDate(startTime)}
+                onInput={(e) => setStartTime((e.target as HTMLInputElement).value)}
+                required={true}
+              />
+            </label>
+
+            <label className="d-flex align-items-center">
+              <p style={{ marginBottom: 0, marginRight: "5px" }}>End:</p>
+              <input
+                type="date"
+                id="end"
+                name="end"
+                min={formatDate(startTime)}
+                max={graphFuture ? undefined : getToday()}
+                value={formatDate(endTime)}
+                onInput={(e) => setEndTime(formatDate(new Date((e.target as HTMLInputElement).value)))}
+                required={true}
+              />
+            </label>
+          </div>
           <OverlayTrigger overlay={<Tooltip>Revert to default date</Tooltip>}>
-            <Button variant="outline-light" size="sm" style={{ marginRight: "5px", border: "grey" }}>
+            <Button variant="outline-light" size="sm" className="border">
               <Link
                 href={
                   searchParams.get("datum")
@@ -129,7 +121,7 @@ export function TimeframeSelector({
               return validDateMessage !== "" ? <Tooltip {...props}>{validDateMessage}</Tooltip> : <span />
             }}
           >
-            <Button variant="primary" size="sm" disabled={!startTime || !endTime || validDateMessage !== ""}>
+            <Button variant="info" size="sm" disabled={!startTime || !endTime || validDateMessage !== ""}>
               <Link
                 href={{
                   pathname,

--- a/src/Features/ERDDAP/types.ts
+++ b/src/Features/ERDDAP/types.ts
@@ -211,8 +211,3 @@ export interface DatumOffsets {
   datum_msl_meters?: number
   datum_mtl_meters?: number
 }
-
-export type TimeFrameRange = {
-  start: Date
-  end: Date
-}

--- a/src/Features/ERDDAP/types.ts
+++ b/src/Features/ERDDAP/types.ts
@@ -211,3 +211,8 @@ export interface DatumOffsets {
   datum_msl_meters?: number
   datum_mtl_meters?: number
 }
+
+export type TimeFrameRange = {
+  start: Date
+  end: Date
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -460,7 +460,7 @@ $dig-opacities: (
   align-items: center;
 }
 
-.timeframe-card {
+.timeframe-card-wl {
   width: fit-content;
   padding: 8px;
   margin-top: 5px;
@@ -471,12 +471,6 @@ $dig-opacities: (
 .observation-timeframe-selector {
   grid-column: 3;
   justify-self: end;
-}
-
-@media (max-width: 1300px) {
-  .timeframe-card {
-    margin-left: 20px;
-  }
 }
 
 @media (max-width: 1040px) {
@@ -494,15 +488,9 @@ $dig-opacities: (
     justify-self: center;
     grid-column: 1;
   }
-  .timeframe-card {
-    margin: 0;
-  }
 }
 
 @media (max-width: 500px) {
-  .timeframe-card .main {
-    width: 95%;
-  }
   .timeframe-label {
     flex-direction: column;
     margin: 0;


### PR DESCRIPTION
@cgalvarino 
#3884 

Adds a button group to render a large graph of the given observation(s) for a particular span of time. Presets are currently limited to 24 hours, 7 days, and 30 days but can be extended/removed/etc..

Note, styling for specifically for mobile/tablet hasn't been implemented yet. I wanted to pause and ask for guidance since the wireframes don't include that particular information. We were thinking perhaps turning the button group into a dropdown?

 Also looking for guidance on possibly combining the timeframe date picker with this new button group. From Charlton's recent email:
> Robin has been working on the new time controls when in the large graph mode.  The start and end pickers are giving us grief.  The mockup has them visible all the time.  But, as you can imagine, it’s easy for it to get out of sync w/ what time control button may be pressed.  Should the start and end times update to match what button you have mashed (e.g., the 24-hour or 2-weeks button)?  How about this instead:  Add a “Custom” (or something) option.  Only when you hit that button  >would you see the date picker and be able to continue down that rabbit hole.

**Before**
<img width="1440" height="523" alt="Screenshot 2026-05-18 at 4 40 56 PM" src="https://github.com/user-attachments/assets/15a114fc-57bd-4312-8535-41634e5234a8" />


**After**
<img width="1440" height="500" alt="Screenshot 2026-05-18 at 4 39 57 PM" src="https://github.com/user-attachments/assets/ed7cc223-a689-402e-a5aa-d12ccb880246" />

**Mobile for your reference**
<img width="362" height="630" alt="Screenshot 2026-05-18 at 4 42 57 PM" src="https://github.com/user-attachments/assets/0defbccd-b569-4641-8633-9d55d5aa2eb3" />
