### PR TITLE
Patch for wind card not directing users to wind combo graph

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
@@ -33,6 +33,13 @@ export const LatestObsCard = ({ unitSystem, timeSeries, platform }: CardDisplayP
     groupName = groupName + " @ " + firstTs.depth + "m"
   }
 
+  // Allow wind group to be directed to combo wind plot
+  const linkTarget = urlPartReplacer(
+    urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
+    ":type",
+    groupName === "Wind" ? groupName.toLowerCase() : firstTs.data_type.standard_name,
+  )
+
   const cardData = Array.isArray(timeSeries)
     ? getGroupData(unitSystem, groupName, timeSeries).getWindOrWaveData()
     : getNonGroupData(unitSystem, timeSeries).getOtherData()
@@ -88,14 +95,7 @@ export const LatestObsCard = ({ unitSystem, timeSeries, platform }: CardDisplayP
             )}
 
             {/* Line chart icon with link */}
-            <Link
-              href={urlPartReplacer(
-                urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
-                ":type",
-                firstTs.data_type.standard_name,
-              )}
-              className="d-flex text-decoration-none mt-auto ms-auto text-info"
-            >
+            <Link href={linkTarget} className="d-flex text-decoration-none mt-auto ms-auto text-info">
               <LineChartIcon className="fa-md" />
             </Link>
           </Card.Body>


### PR DESCRIPTION
@cgalvarino @abkfenris 

Fix for the line chart icon in the new latest obs cards not directing users to the nice combo wind chart. It's a little crude but once we decided how to handle the waves group this could be standardized and built up to allow for extensibility.