### PR TITLE
Station details color & formatting update

### DIFF
--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -38,7 +38,7 @@ export default function Layout({
 
   return (
     <React.Fragment>
-      <Row className="g-5 align-items-stretch">
+      <Row className={`g-5 align-items-stretch ${isPlatformView ? "seaweed-background" : ""}`}>
         <Col xs={12} md={6} className="order-2 d-flex">
           <div className="platform-map-layout flex-fill">
             {/* Second div layer decouples sidebar from map to allow for scrolling */}

--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -51,7 +51,7 @@ export default function Layout({
             <div className={isRegionView ? "region-map-container" : "d-flex h-100"}>
               <ErddapMap
                 // Pass minimum height requirement only on landing page
-                className={`${!(isPlatformView || isRegionView) ? "landing-min-height" : ""} map`}
+                className={`${!(isPlatformView || isRegionView) ? "landing-min-height" : ""} map border-0 rounded-2 overflow-hidden`}
                 {...(isPlatformView && { platformId })}
               />
             </div>

--- a/src/Features/ERDDAP/Platform/Info/index.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.spec.tsx
@@ -31,7 +31,7 @@ describe("ErddapPlatformInfoPanel", () => {
 
     render(<ErddapPlatformInfoPanel platform={platform} />)
 
-    expect(screen.getByRole("header")).toHaveTextContent(platform.id)
+    expect(screen.getByRole("header-id")).toHaveTextContent(platform.id)
     expect(screen.getByRole("complementary")).toHaveTextContent(platform.properties.mooring_site_desc)
     expect(screen.getByRole("complementary")).toHaveTextContent(platform.geometry.coordinates[0].toString())
     expect(screen.getByRole("complementary")).toHaveTextContent(platform.geometry.coordinates[1].toString())

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -21,7 +21,11 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
   return (
     <Card className="p-2" role="complementary">
       <Card.Body className="p-0">
-        {platformId && <p className="m-0 text-black-65">Station {platformId}</p>}
+        {platformId && (
+          <p role="header-id" className="m-0 text-black-65">
+            Station {platformId}
+          </p>
+        )}
         <h2 role="header" className="text-primary pb-3">
           {platformName}
         </h2>

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -8,7 +8,7 @@ import Card from "react-bootstrap/Card"
 import { round } from "Shared/math"
 
 import { UsePlatformRenderProps } from "../../hooks/BuoyBarnComponents"
-import { platformId } from "../../utils/platformName"
+import { platformNameAndId } from "../../utils/platformName"
 import { LocationPinIcon } from "Shared/icons/iconsMap"
 
 /**
@@ -17,14 +17,15 @@ import { LocationPinIcon } from "Shared/icons/iconsMap"
  */
 export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
   const nbdc_site_id = platform.properties.ndbc_site_id ? platform.properties.ndbc_site_id : ""
+  const { platformName, platformId } = platformNameAndId(platform)
   return (
     <Card className="p-2" role="complementary">
       <Card.Body className="p-0">
-        {nbdc_site_id && <p className="m-0 text-black-65">Station {nbdc_site_id}</p>}
+        {platformId && <p className="m-0 text-black-65">Station {platformId}</p>}
         <h2 role="header" className="text-primary pb-3">
-          {platformId(platform)}
+          {platformName}
         </h2>
-        <Card.Text className="d-flex flex-column gap-1">
+        <div className="d-flex flex-column gap-1">
           {nbdc_site_id && (
             <span className="d-flex flex-row gap-2 align-items-baseline">
               <h3 className="text-primary m-0">NDBC ID</h3> <p className="text-black-65 m-0">{nbdc_site_id}</p>
@@ -50,7 +51,7 @@ export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderP
               <a href={attr.program.website}>{attr.attribution}</a>
             </span>
           ))}
-        </Card.Text>
+        </div>
       </Card.Body>
     </Card>
   )

--- a/src/Features/ERDDAP/Platform/Info/index.tsx
+++ b/src/Features/ERDDAP/Platform/Info/index.tsx
@@ -8,7 +8,8 @@ import Card from "react-bootstrap/Card"
 import { round } from "Shared/math"
 
 import { UsePlatformRenderProps } from "../../hooks/BuoyBarnComponents"
-import { platformName } from "../../utils/platformName"
+import { platformId } from "../../utils/platformName"
+import { LocationPinIcon } from "Shared/icons/iconsMap"
 
 /**
  * Platform info panel
@@ -17,26 +18,37 @@ import { platformName } from "../../utils/platformName"
 export const ErddapPlatformInfoPanel: React.FunctionComponent<UsePlatformRenderProps> = ({ platform }) => {
   const nbdc_site_id = platform.properties.ndbc_site_id ? platform.properties.ndbc_site_id : ""
   return (
-    <Card role="complementary">
-      <Card.Body>
-        <Card.Title role="header">Station {platformName(platform)}</Card.Title>
-        <Card.Text>
-          {platform.properties.mooring_site_desc}
-          <br />
-          {nbdc_site_id ? (
-            <React.Fragment>
-              <b>NDBC ID:</b> {nbdc_site_id}
-              <br />
-            </React.Fragment>
-          ) : null}
-          <b>Lat:</b> {round((platform.geometry as Point).coordinates[1] as number)} <b>Lon:</b>{" "}
-          {round((platform.geometry as Point).coordinates[0] as number)}
-          <br />
+    <Card className="p-2" role="complementary">
+      <Card.Body className="p-0">
+        {nbdc_site_id && <p className="m-0 text-black-65">Station {nbdc_site_id}</p>}
+        <h2 role="header" className="text-primary pb-3">
+          {platformId(platform)}
+        </h2>
+        <Card.Text className="d-flex flex-column gap-1">
+          {nbdc_site_id && (
+            <span className="d-flex flex-row gap-2 align-items-baseline">
+              <h3 className="text-primary m-0">NDBC ID</h3> <p className="text-black-65 m-0">{nbdc_site_id}</p>
+            </span>
+          )}
+          {/* Mimics h3 without messing up the html structure */}
+          <span className="text-primary h3-mimic">{platform.properties.mooring_site_desc}</span>
+
+          <span className="d-flex flex-row gap-2 pb-5 align-items-baseline">
+            <LocationPinIcon className="text-primary" />
+            <span className="text-primary h3-mimic">
+              {round((platform.geometry as Point).coordinates[1] as number)}
+            </span>
+            <span className="text-black-65">Lat</span>
+            <span className="text-primary h3-mimic">
+              {round((platform.geometry as Point).coordinates[0] as number)}
+            </span>
+            <span className="text-black-65 m-0">Lon</span>
+          </span>
+
           {platform.properties.attribution.map((attr, key) => (
-            <React.Fragment key={key}>
+            <span className="mt-auto" key={key}>
               <a href={attr.program.website}>{attr.attribution}</a>
-              <br />
-            </React.Fragment>
+            </span>
           ))}
         </Card.Text>
       </Card.Body>

--- a/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCards.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCards.tsx
@@ -34,7 +34,7 @@ export const ErddapObservationCards: React.FC<Props> = ({
   const times = nonGroupTimeSeries.filter((d) => d.time !== null).map((d) => new Date(d.time as string))
   times.sort((a, b) => a.valueOf() - b.valueOf())
   return (
-    <div className="d-flex flex-column bg-black bg-opacity-5 rounded-3 p-2">
+    <div className="d-flex flex-column rounded-3 p-2 bg-white">
       <h3>Latest Conditions</h3>
       {times.length > 0 ? (
         <span className="d-flex flex-row">

--- a/src/Features/ERDDAP/utils/platformName.ts
+++ b/src/Features/ERDDAP/utils/platformName.ts
@@ -8,6 +8,11 @@ interface PlatformName extends Feature {
   properties: PlatformNameProp
 }
 
+type PlatformNameAndId = {
+  platformName: string | undefined
+  platformId: string
+}
+
 /**
  * Renders the platform name from the slug and the optional specified name in the API
  * @param platform a subset of platform info
@@ -22,12 +27,9 @@ export function platformName(platform: PlatformName) {
   return name
 }
 
-export function platformId(platform: PlatformName) {
-  let name = platform.id
-
-  if (platform.properties.station_name && platform.properties.station_name !== "") {
-    name = platform.properties.station_name
+export function platformNameAndId(platform: PlatformName): PlatformNameAndId {
+  return {
+    platformName: platform.properties.station_name,
+    platformId: platform.id,
   }
-
-  return name
 }

--- a/src/Features/ERDDAP/utils/platformName.ts
+++ b/src/Features/ERDDAP/utils/platformName.ts
@@ -21,3 +21,13 @@ export function platformName(platform: PlatformName) {
 
   return name
 }
+
+export function platformId(platform: PlatformName) {
+  let name = platform.id
+
+  if (platform.properties.station_name && platform.properties.station_name !== "") {
+    name = platform.properties.station_name
+  }
+
+  return name
+}

--- a/src/Shared/icons/iconsMap.ts
+++ b/src/Shared/icons/iconsMap.ts
@@ -17,6 +17,7 @@ import {
   faArrowDown,
   faChartLine,
   faCircleInfo,
+  faLocationPin,
 } from "@fortawesome/free-solid-svg-icons"
 import mkIcon from "./iconComponent"
 
@@ -32,3 +33,4 @@ export const ArrowRightIcon = mkIcon(faArrowRight)
 export const ArrowUpIcon = mkIcon(faArrowUp)
 export const ArrowDownIcon = mkIcon(faArrowDown)
 export const LineChartIcon = mkIcon(faChartLine)
+export const LocationPinIcon = mkIcon(faLocationPin)

--- a/src/index.scss
+++ b/src/index.scss
@@ -39,6 +39,7 @@ $dig-colors: (
   "orange": $orange,
 );
 
+$black-5: transparentize($black, 0.05);
 $black-20: transparentize($black, 0.2);
 $black-65: transparentize($black, 0.65);
 $seaweed-10: transparentize($seaweed, 0.1);
@@ -127,6 +128,19 @@ a {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.25rem;
+}
+
+.h3-mimic {
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.text-black-20 {
+  color: $black-20;
+}
+
+.text-black-65 {
+  color: $black-65;
 }
 // ========== TYPOGRAPHY END ==========
 
@@ -278,10 +292,6 @@ $dig-opacities: (
   }
 }
 
-.text-black-65 {
-  color: rgba(0, 0, 0, 0.65);
-}
-
 .black-65 {
   color: rgba(0, 0, 0, 0.65);
 }
@@ -291,7 +301,14 @@ $dig-opacities: (
 }
 
 // ==== LATEST CONDITIONS END ====
+// ==== GENERAL STATION DETAILS STARTT ====
+.seaweed-background {
+  background-color: $info;
+  margin: -20px -20px -0px -20px;
+  padding: 0px 10px 20px;
+}
 
+// ==== GENERAL STATION DETAILS END ====
 .superlatives-tooltip .tooltip-inner {
   max-width: none;
 }

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -99,48 +99,93 @@ exports[`Storybook Snapshot Tests > Components/Footer > footer 1`] = `
 exports[`Storybook Snapshot Tests > ERDDAP/Info/Panel > platformInfo 1`] = `
 <div>
   <div
-    class="card"
+    class="p-2 card"
     role="complementary"
   >
     <div
-      class="card-body"
+      class="p-0 card-body"
     >
-      <div
-        class="card-title h5"
-        role="header"
+      <p
+        class="m-0 text-black-65"
       >
         Station 
-        M01
-      </div>
-      <p
-        class="card-text"
-      >
-        Jordan Basin
-        <br />
-        <b>
-          NDBC ID:
-        </b>
-         
         44037
-        <br />
-        <b>
-          Lat:
-        </b>
-         
-        43.5
-         
-        <b>
-          Lon:
-        </b>
-         
-        -67.87
-        <br />
-        <a
-          href="http://gyre.umeoce.maine.edu/gomoos.php"
+      </p>
+      <h2
+        class="text-primary pb-3"
+        role="header"
+      >
+        M01
+      </h2>
+      <p
+        class="d-flex flex-column gap-1 card-text"
+      >
+        <span
+          class="d-flex flex-row gap-2 align-items-baseline"
         >
-          University of Maine
-        </a>
-        <br />
+          <h3
+            class="text-primary m-0"
+          >
+            NDBC ID
+          </h3>
+           
+          <p
+            class="text-black-65 m-0"
+          >
+            44037
+          </p>
+        </span>
+        <span
+          class="text-primary h3-mimic"
+        >
+          Jordan Basin
+        </span>
+        <span
+          class="d-flex flex-row gap-2 pb-5 align-items-baseline"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-location-pin text-primary"
+            data-icon="location-pin"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M192 0C86 0 0 84.4 0 188.6 0 307.9 120.2 450.9 170.4 505.4 182.2 518.2 201.8 518.2 213.6 505.4 263.8 450.9 384 307.9 384 188.6 384 84.4 298 0 192 0z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="text-primary h3-mimic"
+          >
+            43.5
+          </span>
+          <span
+            class="text-black-65"
+          >
+            Lat
+          </span>
+          <span
+            class="text-primary h3-mimic"
+          >
+            -67.87
+          </span>
+          <span
+            class="text-black-65 m-0"
+          >
+            Lon
+          </span>
+        </span>
+        <span
+          class="mt-auto"
+        >
+          <a
+            href="http://gyre.umeoce.maine.edu/gomoos.php"
+          >
+            University of Maine
+          </a>
+        </span>
       </p>
     </div>
   </div>

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -109,16 +109,14 @@ exports[`Storybook Snapshot Tests > ERDDAP/Info/Panel > platformInfo 1`] = `
         class="m-0 text-black-65"
       >
         Station 
-        44037
+        M01
       </p>
       <h2
         class="text-primary pb-3"
         role="header"
-      >
-        M01
-      </h2>
-      <p
-        class="d-flex flex-column gap-1 card-text"
+      />
+      <div
+        class="d-flex flex-column gap-1"
       >
         <span
           class="d-flex flex-row gap-2 align-items-baseline"
@@ -186,7 +184,7 @@ exports[`Storybook Snapshot Tests > ERDDAP/Info/Panel > platformInfo 1`] = `
             University of Maine
           </a>
         </span>
-      </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/stories/__snapshots__/storyshots.spec.ts.snap
+++ b/src/stories/__snapshots__/storyshots.spec.ts.snap
@@ -107,6 +107,7 @@ exports[`Storybook Snapshot Tests > ERDDAP/Info/Panel > platformInfo 1`] = `
     >
       <p
         class="m-0 text-black-65"
+        role="header-id"
       >
         Station 
         M01

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -21,8 +21,8 @@ test.describe("Platform A01", () => {
 
   test("Shows platform status", async ({ page }) => {
     await page.goto(platformUrl)
-    await expect(page.getByText(/Lat:/).first()).toBeVisible()
-    await expect(page.getByText(/Lon:/).first()).toBeVisible()
+    await expect(page.getByText(/Lat/).first()).toBeVisible()
+    await expect(page.getByText(/Lon/).first()).toBeVisible()
     await expect(page.getByText(/Last updated/).first()).toBeVisible()
   })
 

--- a/tests/e2e/Platform/mooring_location_regression.spec.ts
+++ b/tests/e2e/Platform/mooring_location_regression.spec.ts
@@ -5,21 +5,11 @@ import { test, expect } from "@playwright/test"
 test.describe("Mooring location regressions", () => {
   test("Finds the correct location for B01", async ({ page }) => {
     await page.goto("/platform/B01")
-    await expect(
-      page
-        .locator(".card-title")
-        .getByText(/Western Maine Shelf/)
-        .first(),
-    ).toBeVisible()
+    await expect(page.getByText(/Western Maine Shelf/).first()).toBeVisible()
   })
 
   test("Finds the correct location for I01", async ({ page }) => {
     await page.goto("/platform/I01")
-    await expect(
-      page
-        .locator(".card-title")
-        .getByText(/Eastern Maine Shelf/)
-        .first(),
-    ).toBeVisible()
+    await expect(page.getByText(/Eastern Maine Shelf/).first()).toBeVisible()
   })
 })


### PR DESCRIPTION
@cgalvarino 
#3875 -- middle version shown in comments

Updates to the whole top half of the page as well as formatting and styling of the station information card.

Question: I'm unclear as to whether these little nubbins at the bottom of the seaweed background were intended to be developed or not, pretty sure it wouldn't be problem to do but seemed unusual.
<img width="647" height="74" alt="Screenshot 2026-05-19 at 11 50 48 AM" src="https://github.com/user-attachments/assets/36d82154-7591-4575-96ad-cff9eef2bfaa" />

**Specs & Goal**
Station Heading
- Station 3: 'Paragraph', Black 65
- Title: 'H2', Blue

Station Description
- Numbers: 'H3', Blue
- Subtext: 'Paragraph', Black 65

Link
- 'Link', Blue

<img width="886" height="331" alt="Screenshot 2026-05-19 at 11 54 17 AM" src="https://github.com/user-attachments/assets/e2ca04df-d5ad-4a38-901a-1598f940b042" />

**After**
<img width="1440" height="765" alt="Screenshot 2026-05-19 at 11 55 51 AM" src="https://github.com/user-attachments/assets/5d334445-c39a-45c7-aec1-6dc487f3d32b" />

<img width="194" height="423" alt="Screenshot 2026-05-19 at 11 56 35 AM" src="https://github.com/user-attachments/assets/2ea83cc3-d06b-48b2-a304-8f12d05c82f8" />
<img width="194" height="423" alt="Screenshot 2026-05-19 at 11 56 50 AM" src="https://github.com/user-attachments/assets/ff9da2fb-7dbe-4a97-acce-e3c5290e7a38" />

**Before**
<img width="1440" height="674" alt="Screenshot 2026-05-19 at 11 57 33 AM" src="https://github.com/user-attachments/assets/c157710d-ba33-40c8-b607-d7b5fb40cdd4" />


