### PR TITLE
Station Details: chart cards

### DIFF
--- a/app/(platformMap)/@bottom/platform/[platformId]/current_conditions.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/current_conditions.tsx
@@ -10,7 +10,7 @@ export function CurrentConditions({ platformId }: { platformId: string }) {
     <UsePlatform platformId={platformId}>
       {({ platform }: { platform: PlatformFeature }) => {
         return (
-          <Row className="align-items-start">
+          <Row className="align-items-start px-0">
             <Col xs={12} md={12} className="mb-4">
               <ErddapCurrentPlatformConditions platform={platform} />
             </Col>

--- a/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
@@ -28,7 +28,7 @@ export function PlatformTabs() {
     <UsePlatform platformId={id}>
       {(platform_props) => (
         <React.Fragment>
-          <Row className="pb-4">
+          <Row className="pb-4 px-0">
             <Col>
               <Nav variant="tabs">
                 <ErddapObservedDropdown {...platform_props} />

--- a/app/(platformMap)/layout.tsx
+++ b/app/(platformMap)/layout.tsx
@@ -51,7 +51,7 @@ export default function Layout({
             <div className={isRegionView ? "region-map-container" : "d-flex h-100"}>
               <ErddapMap
                 // Pass minimum height requirement only on landing page
-                className={`${!(isPlatformView || isRegionView) ? "landing-min-height" : ""} map`}
+                className={`${!(isPlatformView || isRegionView) ? "landing-min-height" : ""} map border-0 rounded-2 overflow-hidden`}
                 {...(isPlatformView && { platformId })}
               />
             </div>

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/common_card.ts
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/common_card.ts
@@ -6,13 +6,6 @@ import { urlPartReplacer } from "Shared/urlParams"
 
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 
-/** Common props for formatting current conditions cards */
-export const cardProps = {
-  // md: 4,
-  // sm: 6,
-  // className: "h-100"
-}
-
 /**
  * Link to a given platforms observation
  *

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/common_card.ts
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/common_card.ts
@@ -8,8 +8,9 @@ import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 
 /** Common props for formatting current conditions cards */
 export const cardProps = {
-  md: 4,
-  sm: 6,
+  // md: 4,
+  // sm: 6,
+  // className: "h-100"
 }
 
 /**

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
@@ -53,31 +53,31 @@ export function DataCardDisplay({
 
   return (
     <Col>
-      <Card className="chart-card">
-        <Card.Header className="h-100 border-0">
-          <p className="chart-title">
-            <strong>
-              {timeSeries.data_type.long_name} - {round(dataConverter.convertToNumber(latest.reading, unitSystem), 1)}{" "}
-              {dataConverter.displayName(unitSystem)} {convertUnit(timeSeries.data_type.units, latest.reading)}
-            </strong>
-          </p>
-        </Card.Header>
+      <Link href={url}>
+        <Card className="chart-card">
+          <Card.Header className="h-100 border-0">
+            <p className="chart-title">
+              <strong>
+                {timeSeries.data_type.long_name} - {round(dataConverter.convertToNumber(latest.reading, unitSystem), 1)}{" "}
+                {dataConverter.displayName(unitSystem)} {convertUnit(timeSeries.data_type.units, latest.reading)}
+              </strong>
+            </p>
+          </Card.Header>
 
-        <div className="p-1 pt-3">
-          <SmallTimeSeriesChart
-            name={timeSeries.data_type.standard_name}
-            timeSeries={data}
-            unit={dataConverter.displayName(unitSystem)}
-            softMin={bounds[0]}
-            softMax={bounds[1]}
-            data_type={timeSeries.data_type.standard_name}
-            {...{ unitSystem, startTime, endTime }}
-          />
-        </div>
-        <Link href={url} className="ms-auto mt-auto p-2">
-          <ExpandIcon />
-        </Link>
-      </Card>
+          <div className="p-1 pt-3">
+            <SmallTimeSeriesChart
+              name={timeSeries.data_type.standard_name}
+              timeSeries={data}
+              unit={dataConverter.displayName(unitSystem)}
+              softMin={bounds[0]}
+              softMax={bounds[1]}
+              data_type={timeSeries.data_type.standard_name}
+              {...{ unitSystem, startTime, endTime }}
+            />
+          </div>
+          <ExpandIcon className="ms-auto mt-auto p-2" />
+        </Card>
+      </Link>
     </Col>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
@@ -2,8 +2,6 @@
 /**
  * Generalized single time series data card
  */
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faExpand } from "@fortawesome/free-solid-svg-icons"
 import React from "react"
 import Link from "next/link"
 import Card from "react-bootstrap/Card"
@@ -20,7 +18,7 @@ import { ExpandIcon } from "Shared/icons/iconsMap"
 
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 
-import { cardProps, cardUrl } from "./common_card"
+import { cardUrl } from "./common_card"
 
 interface DataCardDisplayProps {
   readings: ReadingTimeSeries[]

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
@@ -16,6 +16,7 @@ import { ReadingTimeSeries } from "Shared/timeSeries"
 import { convertUnit } from "Shared/unitConversion"
 import { UnitSystem } from "Features/Units/types"
 import { converter } from "Features/Units/Converter"
+import { ExpandIcon } from "Shared/icons/iconsMap"
 
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 
@@ -53,28 +54,28 @@ export function DataCardDisplay({
   }))
 
   return (
-    <Col {...cardProps}>
-      <Link href={url}>
-        <Card>
-          <Card.Header>
-            {timeSeries.data_type.long_name} - {round(dataConverter.convertToNumber(latest.reading, unitSystem), 1)}{" "}
-            {dataConverter.displayName(unitSystem)} {convertUnit(timeSeries.data_type.units, latest.reading)}
-          </Card.Header>
+    <Col>
+      <Card className="h-100">
+        <Card.Header className="h-100">
+          {timeSeries.data_type.long_name} - {round(dataConverter.convertToNumber(latest.reading, unitSystem), 1)}{" "}
+          {dataConverter.displayName(unitSystem)} {convertUnit(timeSeries.data_type.units, latest.reading)}
+        </Card.Header>
 
-          <Card.Body style={{ padding: ".2rem" }}>
-            <SmallTimeSeriesChart
-              name={timeSeries.data_type.standard_name}
-              timeSeries={data}
-              unit={dataConverter.displayName(unitSystem)}
-              softMin={bounds[0]}
-              softMax={bounds[1]}
-              data_type={timeSeries.data_type.standard_name}
-              {...{ unitSystem, startTime, endTime }}
-            />
-            <FontAwesomeIcon icon={faExpand} pull="right" />
-          </Card.Body>
-        </Card>
-      </Link>
+        <div className="p-1 pt-3">
+          <SmallTimeSeriesChart
+            name={timeSeries.data_type.standard_name}
+            timeSeries={data}
+            unit={dataConverter.displayName(unitSystem)}
+            softMin={bounds[0]}
+            softMax={bounds[1]}
+            data_type={timeSeries.data_type.standard_name}
+            {...{ unitSystem, startTime, endTime }}
+          />
+        </div>
+        <Link href={url} className="ms-auto mt-auto p-2">
+          <ExpandIcon />
+        </Link>
+      </Card>
     </Col>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/data_card.tsx
@@ -55,10 +55,14 @@ export function DataCardDisplay({
 
   return (
     <Col>
-      <Card className="h-100">
-        <Card.Header className="h-100">
-          {timeSeries.data_type.long_name} - {round(dataConverter.convertToNumber(latest.reading, unitSystem), 1)}{" "}
-          {dataConverter.displayName(unitSystem)} {convertUnit(timeSeries.data_type.units, latest.reading)}
+      <Card className="chart-card">
+        <Card.Header className="h-100 border-0">
+          <p className="chart-title">
+            <strong>
+              {timeSeries.data_type.long_name} - {round(dataConverter.convertToNumber(latest.reading, unitSystem), 1)}{" "}
+              {dataConverter.displayName(unitSystem)} {convertUnit(timeSeries.data_type.units, latest.reading)}
+            </strong>
+          </p>
         </Card.Header>
 
         <div className="p-1 pt-3">

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
@@ -44,7 +44,7 @@ export const ErddapCurrentPlatformConditions: React.FunctionComponent<Props> = (
         const endTime = new Date(times[times.length - 1])
 
         return (
-          <Row xs={1} md={3} className="g-4 align-items-stretch g-2">
+          <Row xs={1} md={3} className="g-5 align-items-stretch g-2">
             {datasets.map((dataset, index) => {
               const datasetTimeSeries = before.find((ts) => ts.variable === dataset.name)
               if (!datasetTimeSeries) {

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
@@ -44,7 +44,7 @@ export const ErddapCurrentPlatformConditions: React.FunctionComponent<Props> = (
         const endTime = new Date(times[times.length - 1])
 
         return (
-          <Row xs={1} lg={3} className="g-2">
+          <Row xs={1} md={3} className="align-items-stretch g-2">
             {datasets.map((dataset, index) => {
               const datasetTimeSeries = before.find((ts) => ts.variable === dataset.name)
               if (!datasetTimeSeries) {

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
@@ -44,7 +44,7 @@ export const ErddapCurrentPlatformConditions: React.FunctionComponent<Props> = (
         const endTime = new Date(times[times.length - 1])
 
         return (
-          <Row xs={1} md={3} className="align-items-stretch g-2">
+          <Row xs={1} md={3} className="g-4 align-items-stretch g-2">
             {datasets.map((dataset, index) => {
               const datasetTimeSeries = before.find((ts) => ts.variable === dataset.name)
               if (!datasetTimeSeries) {

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
@@ -90,11 +90,15 @@ export const DisplayWindCardInner: React.FC<DisplayWindCardProps> = ({
 
   return (
     <Col>
-      <Card className="h-100">
-        <Card.Header className="h-100">
-          Winds{speedTitle}
-          {gustTitle}
-          {directionTitle}
+      <Card className="chart-card">
+        <Card.Header className="h-100 border-0">
+          <p className="chart-title">
+            <strong>
+              Winds{speedTitle}
+              {gustTitle}
+              {directionTitle}
+            </strong>
+          </p>
         </Card.Header>
         <div className="p-1 pt-3">
           <WindTimeSeriesChart

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
@@ -1,8 +1,6 @@
 /**
  * Wind specific current conditions card
  */
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faExpand } from "@fortawesome/free-solid-svg-icons"
 import React from "react"
 import Link from "next/link"
 import Card from "react-bootstrap/Card"
@@ -20,7 +18,7 @@ import { WindTimeSeriesChart } from "components/Charts/WindTimeSeries"
 
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 import { pickWindDatasets, pickWindTimeSeries } from "../../../utils/wind"
-import { cardProps, observationLink } from "./common_card"
+import { observationLink } from "./common_card"
 
 interface DisplayWindCardProps {
   platform: PlatformFeature
@@ -126,7 +124,7 @@ interface OtherWindCardProps {
  * Card to display various information when the wind data is not avaliable or loaded
  */
 const OtherWindCard: React.FunctionComponent<OtherWindCardProps> = ({ platform, children }) => (
-  <Col {...cardProps}>
+  <Col>
     <Link href={observationLink(platform, "wind")}>
       <Card>
         <Card.Header>{children}</Card.Header>

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
@@ -14,6 +14,7 @@ import { DataTimeSeries } from "Shared/timeSeries"
 import { compassDirection } from "Shared/unitConversion/compassDirection"
 import { UnitSystem } from "Features/Units/types"
 import { converter } from "Features/Units/Converter"
+import { ExpandIcon } from "Shared/icons/iconsMap"
 
 import { WindTimeSeriesChart } from "components/Charts/WindTimeSeries"
 
@@ -88,26 +89,26 @@ export const DisplayWindCardInner: React.FC<DisplayWindCardProps> = ({
   }
 
   return (
-    <Col {...cardProps}>
-      <Link href={observationLink(platform, "wind")}>
-        <Card>
-          <Card.Header>
-            Winds{speedTitle}
-            {gustTitle}
-            {directionTitle}
-          </Card.Header>
-          <Card.Body style={{ padding: ".2rem" }}>
-            <WindTimeSeriesChart
-              days={1}
-              barbsPerDay={24}
-              legend={false}
-              height={150}
-              {...{ speed, gust, direction, unitSystem, startTime, endTime }}
-            />
-            <FontAwesomeIcon icon={faExpand} pull="right" />
-          </Card.Body>
-        </Card>
-      </Link>
+    <Col>
+      <Card className="h-100">
+        <Card.Header className="h-100">
+          Winds{speedTitle}
+          {gustTitle}
+          {directionTitle}
+        </Card.Header>
+        <div className="p-1 pt-3">
+          <WindTimeSeriesChart
+            days={1}
+            barbsPerDay={24}
+            legend={false}
+            height={150}
+            {...{ speed, gust, direction, unitSystem, startTime, endTime }}
+          />
+        </div>
+        <Link href={observationLink(platform, "wind")} className="ms-auto mt-auto p-2">
+          <ExpandIcon />
+        </Link>
+      </Card>
     </Col>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/wind.tsx
@@ -88,29 +88,29 @@ export const DisplayWindCardInner: React.FC<DisplayWindCardProps> = ({
 
   return (
     <Col>
-      <Card className="chart-card">
-        <Card.Header className="h-100 border-0">
-          <p className="chart-title">
-            <strong>
-              Winds{speedTitle}
-              {gustTitle}
-              {directionTitle}
-            </strong>
-          </p>
-        </Card.Header>
-        <div className="p-1 pt-3">
-          <WindTimeSeriesChart
-            days={1}
-            barbsPerDay={24}
-            legend={false}
-            height={150}
-            {...{ speed, gust, direction, unitSystem, startTime, endTime }}
-          />
-        </div>
-        <Link href={observationLink(platform, "wind")} className="ms-auto mt-auto p-2">
-          <ExpandIcon />
-        </Link>
-      </Card>
+      <Link href={observationLink(platform, "wind")}>
+        <Card className="chart-card">
+          <Card.Header className="h-100 border-0">
+            <p className="chart-title">
+              <strong>
+                Winds{speedTitle}
+                {gustTitle}
+                {directionTitle}
+              </strong>
+            </p>
+          </Card.Header>
+          <div className="p-1 pt-3">
+            <WindTimeSeriesChart
+              days={1}
+              barbsPerDay={24}
+              legend={false}
+              height={150}
+              {...{ speed, gust, direction, unitSystem, startTime, endTime }}
+            />
+          </div>
+          <ExpandIcon className="ms-auto mt-auto p-2" />
+        </Card>
+      </Link>
     </Col>
   )
 }

--- a/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
@@ -48,59 +48,60 @@ export const LatestObsCard = ({ unitSystem, timeSeries, platform }: CardDisplayP
   }
 
   return (
-    <Col className="d-flex latest-obs-card">
-      <Sentry.ErrorBoundary fallback={<b>Error displaying {firstTs.data_type.long_name}</b>} showDialog={false}>
-        <Card className="flex-fill card-drop-shadow">
-          <Card.Body className="d-flex flex-column p-4 p-lg-2">
-            {/* Bucket name */}
-            <p className="text-black-65 mb-0">{groupName}</p>
+    <Link
+      href={urlPartReplacer(
+        urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
+        ":type",
+        firstTs.data_type.standard_name,
+      )}
+      className="d-flex text-decoration-none text-info"
+    >
+      <Col className="d-flex latest-obs-card">
+        <Sentry.ErrorBoundary fallback={<b>Error displaying {firstTs.data_type.long_name}</b>} showDialog={false}>
+          <Card className="flex-fill card-drop-shadow">
+            <Card.Body className="d-flex flex-column p-4 p-lg-2">
+              {/* Bucket name */}
+              <p className="text-black-65 mb-0">{groupName}</p>
 
-            {/* Primary value and unit */}
-            <span className="d-flex flex-row align-items-end">
-              <h1 className="mb-0">{cardData.primary}</h1>
-              <p className="text-black-65 ms-1 m-0">{cardData.primaryUnit}</p>
-            </span>
-
-            {/* Secondary info -- gust/period */}
-            <span>
-              <strong data-testid={groupName === "Wind" && "wind-test-id"}>
-                {groupName === "Wind" && cardData.secondary && "Gust: "}
-                {groupName === "Waves" && cardData.secondary && "Period: "}
-                {cardData.secondary} {cardData.secondaryUnit}
-              </strong>
-            </span>
-
-            {/* Direction */}
-            {cardData.direction && (
-              <span className="d-flex flex-row align-items-center gap-2">
-                <p className="mb-0">
-                  <strong>
-                    {cardData.direction}
-                    {cardData.directionUnit}
-                  </strong>
-                </p>
-                <LocationArrowIcon
-                  className="fa-sm text-info"
-                  rotateBy
-                  style={{ "--fa-rotate-angle": `${rotationDeg}deg` }}
-                />
+              {/* Primary value and unit */}
+              <span className="d-flex flex-row align-items-end">
+                <h1 className="mb-0">{cardData.primary}</h1>
+                <p className="text-black-65 ms-1 m-0">{cardData.primaryUnit}</p>
               </span>
-            )}
 
-            {/* Line chart icon with link */}
-            <Link
-              href={urlPartReplacer(
-                urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
-                ":type",
-                firstTs.data_type.standard_name,
+              {/* Secondary info -- gust/period */}
+              <span>
+                <strong data-testid={groupName === "Wind" && "wind-test-id"}>
+                  {groupName === "Wind" && cardData.secondary && "Gust: "}
+                  {groupName === "Waves" && cardData.secondary && "Period: "}
+                  {cardData.secondary} {cardData.secondaryUnit}
+                </strong>
+              </span>
+
+              {/* Direction */}
+              {cardData.direction && (
+                <span className="d-flex flex-row align-items-center gap-2">
+                  <p className="mb-0">
+                    <strong>
+                      {cardData.direction}
+                      {cardData.directionUnit}
+                    </strong>
+                  </p>
+                  <LocationArrowIcon
+                    className="fa-sm text-info"
+                    rotateBy
+                    style={{ "--fa-rotate-angle": `${rotationDeg}deg` }}
+                  />
+                </span>
               )}
-              className="d-flex text-decoration-none mt-auto ms-auto text-info"
-            >
-              <LineChartIcon className="fa-md" />
-            </Link>
-          </Card.Body>
-        </Card>
-      </Sentry.ErrorBoundary>
-    </Col>
+
+              {/* Line chart icon with link */}
+
+              <LineChartIcon className="fa-md mt-auto ms-auto" />
+            </Card.Body>
+          </Card>
+        </Sentry.ErrorBoundary>
+      </Col>
+    </Link>
   )
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -290,6 +290,16 @@ $dig-opacities: (
   box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.25);
 }
 
+.chart-card {
+  box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.25);
+  height: 100%;
+  border: none;
+}
+
+.chart-title {
+  color: $primary;
+  margin-bottom: 0px;
+}
 // ==== LATEST CONDITIONS END ====
 
 .superlatives-tooltip .tooltip-inner {

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -39,10 +39,7 @@ test.describe("Platform A01", () => {
 
   test("Shows air temp plot", async ({ page }) => {
     await page.goto(platformUrl)
-    await page
-      .getByText(/Air Temperature -/)
-      .first()
-      .click()
+    await page.locator("div:nth-child(5) > .chart-card > .ms-auto").first().click()
     await expect(
       page
         .locator("h2")

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -39,7 +39,10 @@ test.describe("Platform A01", () => {
 
   test("Shows air temp plot", async ({ page }) => {
     await page.goto(platformUrl)
-    await page.locator("div:nth-child(5) > .chart-card > .ms-auto").first().click()
+    await page
+      .getByText(/Air Temperature -/)
+      .first()
+      .click()
     await expect(
       page
         .locator("h2")


### PR DESCRIPTION
@cgalvarino 
#3875 -- Middle option in comments

Style and format the chart cards on the station detail page. Not a lot of explicit specs given on the wireframe so I did my best to emulate the diagram by eye. 

Notable changes:
- Cards now stretch to all be the same size
- Headers stretch to same size within row
- Drop shadow added
- Border removed
- Icon swapped out for `<ExpandIcon />`
- Card title style to blue paragraph bold

**Goal**
<img width="863" height="588" alt="Screenshot 2026-05-19 at 2 21 28 PM" src="https://github.com/user-attachments/assets/5fc0af5f-9cc2-4df2-a975-7dcab9a29098" />


**After**
<img width="1440" height="608" alt="Screenshot 2026-05-19 at 2 21 49 PM" src="https://github.com/user-attachments/assets/cc9de396-5668-4a31-8502-1131487034f6" />


**Before**
<img width="1440" height="536" alt="Screenshot 2026-05-19 at 2 22 33 PM" src="https://github.com/user-attachments/assets/104d055e-f7bd-43a8-95cd-e68a6107a61a" />

