### PR TITLE
Patch to filter out duplicate data in allCurrentConditionsTimeseries.

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/CurrentConditions/index.tsx
@@ -28,8 +28,14 @@ export const ErddapCurrentPlatformConditions: React.FunctionComponent<Props> = (
   const unitSystem = useUnitSystem()
 
   const halfDayAgo = halfADayAgoRounded()
-  const { before, windTimeSeries, waveTimeSeries, timeSeries, after, allCurrentConditionsTimeseries } =
-    currentConditionsTimeseries(platform, halfDayAgo)
+  const {
+    beforeWithoutGroups,
+    windTimeSeries,
+    waveTimeSeries,
+    timeSeries,
+    afterWithoutGroups,
+    allCurrentConditionsTimeseries,
+  } = currentConditionsTimeseries(platform, halfDayAgo)
 
   return (
     <UseDatasets timeSeries={allCurrentConditionsTimeseries} startTime={halfDayAgo} platformId={platform.id}>
@@ -46,7 +52,7 @@ export const ErddapCurrentPlatformConditions: React.FunctionComponent<Props> = (
         return (
           <Row xs={1} md={3} className="g-5 align-items-stretch g-2">
             {datasets.map((dataset, index) => {
-              const datasetTimeSeries = before.find((ts) => ts.variable === dataset.name)
+              const datasetTimeSeries = beforeWithoutGroups.find((ts) => ts.variable === dataset.name)
               if (!datasetTimeSeries) {
                 return null
               }
@@ -93,7 +99,7 @@ export const ErddapCurrentPlatformConditions: React.FunctionComponent<Props> = (
             })}
 
             {datasets.map((dataset, index) => {
-              const datasetTimeSeries = after.find((ts) => ts.variable === dataset.name)
+              const datasetTimeSeries = afterWithoutGroups.find((ts) => ts.variable === dataset.name)
               if (!datasetTimeSeries) {
                 return null
               }

--- a/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/item.spec.tsx
@@ -91,7 +91,7 @@ describe("TableItem", () => {
   it("Selectes and renders correct data", () => {
     render(<TableItem platform={platform} timeSeries={windSpeed} unitSystem={UnitSystem.english} />)
 
-    expect(screen.findByText("Wind"))
+    expect(screen.findByText("Wind Speed"))
   })
 
   it("Rounds the wind speed", () => {

--- a/src/Features/ERDDAP/Platform/Observations/Table/table.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Table/table.spec.tsx
@@ -19,8 +19,8 @@ describe("<ErddapObservationTable>", () => {
     )
 
     expect(screen.getAllByRole("link").length).toBe(6)
-    expect(screen.findByText("Last Updated"))
-    expect(screen.findByText("Wind: 3.9 kts"))
+    expect(screen.findByText("Last updated"))
+    expect(screen.findByText("Wind Speed: 3.9 kts"))
   })
 
   it("Should show selected observations in metric", () => {
@@ -33,7 +33,7 @@ describe("<ErddapObservationTable>", () => {
     )
 
     expect(screen.getAllByRole("link").length).toBe(6)
-    expect(screen.findByText("Last Updated"))
+    expect(screen.findByText("Last updated"))
     expect(screen.findByText("Wind Speed: 2 m/s"))
   })
 })

--- a/src/Features/ERDDAP/utils/currentConditionsTimeseries.ts
+++ b/src/Features/ERDDAP/utils/currentConditionsTimeseries.ts
@@ -50,15 +50,37 @@ export function currentConditionsTimeseries(platform: PlatformFeature, laterThan
   const timeSeriesWithNull = [waterTemp, airTemp, airPressure, waterLevel, visibility]
   const timeSeries = timeSeriesWithNull.filter((ts) => ts !== null) as PlatformTimeSeries[]
 
-  const nonGroupTimeSeriesWithNull = [...before, waterTemp, airTemp, airPressure, waterLevel, visibility, ...after]
+  const beforeWithoutGroups = before.filter((ts) => !waveTimeSeries.includes(ts) && !windTimeSeries.includes(ts))
+  const afterWithoutGroups = after.filter((ts) => !waveTimeSeries.includes(ts) && !windTimeSeries.includes(ts))
+  const nonGroupTimeSeriesWithNull = [
+    ...beforeWithoutGroups,
+    waterTemp,
+    airTemp,
+    airPressure,
+    waterLevel,
+    visibility,
+    ...afterWithoutGroups,
+  ]
   const nonGroupTimeSeries = nonGroupTimeSeriesWithNull.filter((ts) => ts !== null) as PlatformTimeSeries[]
 
-  const allWithNull = [...before, ...windTimeSeries, ...waveTimeSeries, ...timeSeries, ...after]
-  const allCurrentConditionsTimeseries = allWithNull.filter((ts) => ts !== null) as PlatformTimeSeries[]
+  const allWithNull = [
+    ...beforeWithoutGroups,
+    ...windTimeSeries,
+    ...waveTimeSeries,
+    ...timeSeries,
+    ...afterWithoutGroups,
+  ]
+  const allCurrentConditionsTimeseries = allWithNull.filter((ts) => ts !== null)
+
+  console.log(nonGroupTimeSeries)
+  console.log(waveTimeSeries)
+  console.log(allCurrentConditionsTimeseries)
 
   return {
     before,
     after,
+    beforeWithoutGroups,
+    afterWithoutGroups,
     windTimeSeries,
     waveTimeSeries,
     nonGroupTimeSeries,


### PR DESCRIPTION
@cgalvarino 


`allCurrentConditionsTimeseries.ts` was returning duplicate data in the final `before` and `after` arrays. To allow for backwards compatibility, I added two arrays -- `beforeWithoutGroups` and `afterWithoutGroups`. These just don't include data from the wind and wave groups.

I believe the small charts were crashing because duplicate queries were being sent to backend.

**EXRX working appropriately now**
<img width="1899" height="934" alt="Screenshot 2026-05-20 at 2 26 01 PM" src="https://github.com/user-attachments/assets/46a79e78-5c00-40d0-bd50-6943f9eaa010" />