### PR TITLE
Add missing key props to maps

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -48,7 +48,7 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
     const depth = ts.depth && ts.depth > 0 ? " at " + ts.depth + "m below" : ""
 
     return (
-      <div>
+      <div key={ts.depth ? ts.depth : index} className="d-flex flex-column gap-2">
         <h2 className="d-flex gap-2 justify-content-center align-items-center">
           {ts.data_type.long_name} {depth} <Info timeSeries={[ts]} id={index} startDate={startDate} />
         </h2>

--- a/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCards.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCards.tsx
@@ -54,10 +54,10 @@ export const ErddapObservationCards: React.FC<Props> = ({
       )}
       <Row xs={2} sm={3} md={2} lg={3} xl={3} xxl={4} className="w-100 g-1">
         {waveTimeSeries.length > 0 && (
-          <LatestObsCard timeSeries={waveTimeSeries} platform={platform} unitSystem={unitSystem} />
+          <LatestObsCard key="wave" timeSeries={waveTimeSeries} platform={platform} unitSystem={unitSystem} />
         )}
         {windTimeSeries.length > 0 && (
-          <LatestObsCard timeSeries={windTimeSeries} platform={platform} unitSystem={unitSystem} />
+          <LatestObsCard key="wind" timeSeries={windTimeSeries} platform={platform} unitSystem={unitSystem} />
         )}
         {nonGroupTimeSeries.map((ts, index) => {
           return <LatestObsCard key={index} timeSeries={ts} platform={platform} unitSystem={unitSystem} />


### PR DESCRIPTION
There were a few spots where we were mapping over components (or next to mapped components), that were missing key props to allow react to track them.