### PR TITLE
Add region and platform fallback

### DIFF
--- a/app/(platformMap)/@sidebar/platform/page.tsx
+++ b/app/(platformMap)/@sidebar/platform/page.tsx
@@ -1,3 +1,5 @@
-export default function PlatformList() {
-  return <div>List of platforms</div>
+import RegionIndexSidebar from "../region/page"
+
+export default function PlatformMapSidebar() {
+  return <RegionIndexSidebar />
 }

--- a/app/(platformMap)/@sidebar/region/[regionId]/page.tsx
+++ b/app/(platformMap)/@sidebar/region/[regionId]/page.tsx
@@ -1,10 +1,11 @@
 import { use } from "react"
-import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
 
+import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
 import { Region, regionPageList } from "Shared/regions"
+import { useDecodedUrl } from "util/hooks"
 
 import { RegionList, NextRegion } from "./region"
-import { useDecodedUrl } from "util/hooks"
+import RegionIndexSidebar from "../page"
 
 export default function RegionSidebar(props: { params: Promise<{ regionId: string }> }) {
   const params = use(props.params)
@@ -13,7 +14,7 @@ export default function RegionSidebar(props: { params: Promise<{ regionId: strin
   let region: Region | undefined = regionPageList.find((r) => r.slug === regionId)
 
   if (typeof region === "undefined") {
-    return null
+    return <RegionIndexSidebar />
   }
 
   return (

--- a/app/(platformMap)/@sidebar/region/page.tsx
+++ b/app/(platformMap)/@sidebar/region/page.tsx
@@ -1,0 +1,19 @@
+import Card from "react-bootstrap/Card"
+import Link from "next/link"
+
+import { regionMenuList } from "Shared/regions"
+
+export default function RegionIndexSidebar() {
+  return (
+    <Card className="p-2">
+      <h2>Regions</h2>
+      <ul>
+        {regionMenuList.map((r) => (
+          <li key={r.slug}>
+            <Link href={`/region/${r.slug}`}>{r.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  )
+}

--- a/src/Features/ERDDAP/hooks/BuoyBarnComponents.tsx
+++ b/src/Features/ERDDAP/hooks/BuoyBarnComponents.tsx
@@ -62,6 +62,8 @@ interface UsePlatformProps extends BaseProps {
   children: (props: UsePlatformRenderProps) => React.ReactNode
   /** Platform to try to render */
   platformId: string
+  /** Optional fallback if the platform is not found */
+  fallback?: React.ReactNode
 }
 
 export interface UsePlatformRenderProps {
@@ -76,8 +78,15 @@ export interface UsePlatformRenderProps {
  * @param platformId Platform ID string to try to load
  * @param loading Override default loading alert
  * @param error Override default error alert
+ * @param fallback Optional fallback if the platform is not found
  */
-export const UsePlatform: React.FunctionComponent<UsePlatformProps> = ({ children, loading, error, platformId }) => (
+export const UsePlatform: React.FunctionComponent<UsePlatformProps> = ({
+  children,
+  loading,
+  error,
+  platformId,
+  fallback,
+}) => (
   <UsePlatforms {...{ loading, error }}>
     {({ platforms }) => {
       const platform = platforms.find((p) => (p.id as string) === platformId)
@@ -88,6 +97,10 @@ export const UsePlatform: React.FunctionComponent<UsePlatformProps> = ({ childre
 
       if (error) {
         return error
+      }
+
+      if (fallback) {
+        return fallback
       }
 
       return <WarningAlert>Unable to load platform information for {decodeURIComponent(platformId)}.</WarningAlert>

--- a/src/components/PlatformInfo/platformInfo.tsx
+++ b/src/components/PlatformInfo/platformInfo.tsx
@@ -8,6 +8,8 @@ import { UsePlatform } from "Features/ERDDAP/hooks/BuoyBarnComponents"
 import { UnitSelector, useUnitSystem } from "Features/Units"
 import { aDayAgoRounded } from "Shared/time"
 
+import RegionIndexSidebar from "../../../app/(platformMap)/@sidebar/region/page"
+
 /**
  * Display our platform info panel for the select platform.
  */
@@ -15,7 +17,7 @@ export const PlatformInfo = ({ id }: { id: string }) => {
   const unitSystem = useUnitSystem()
   const aDayAgo = aDayAgoRounded()
   return (
-    <UsePlatform platformId={id}>
+    <UsePlatform platformId={id} fallback={<RegionIndexSidebar />}>
       {({ platform }) => (
         <div className="d-flex flex-column gap-2">
           <PlatformAlerts platform={platform} />


### PR DESCRIPTION
Adds a fallback list of regions to display when an invalid region is chosen (like a link from one of the previous regions).

This list is also displayed at the `/region/` and `/platform/` when they don’t have a region or platform specified. Additionally it is shown when an invalid platform ID is given.

Old region

<img width="1362" height="609" alt="image" src="https://github.com/user-attachments/assets/9976a773-e7bb-47d8-9326-fd9a42648309" />

How old regions used to be displayed

<img width="1367" height="710" alt="image" src="https://github.com/user-attachments/assets/d6c4f8dd-4f6a-45f6-9b35-8e5b7862d1df" />


Base region/platform

<img width="1369" height="523" alt="image" src="https://github.com/user-attachments/assets/f60049c9-f3a1-4434-ad00-9a85da24b37e" />

<img width="1367" height="514" alt="image" src="https://github.com/user-attachments/assets/69712023-b8d0-4ede-b366-93d560b8095c" />

And an invalid platform

<img width="1368" height="732" alt="image" src="https://github.com/user-attachments/assets/b7f2eca5-9640-41fe-8c95-bddd0cb3d63c" />

Previously how an invalid platform would be displayed

<img width="1367" height="417" alt="image" src="https://github.com/user-attachments/assets/19af9a71-c40e-4f45-8b4e-60ba604bf419" />


xref #4117

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4124 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #4121 
<!-- GitButler Footer Boundary Bottom -->

