### PR TITLE
Fix long unit name overflow on latest conditions cards

### DIFF
--- a/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
@@ -71,7 +71,7 @@ export const LatestObsCard = ({ unitSystem, timeSeries, platform }: CardDisplayP
               <p className="text-black-65 mb-0">{groupName}</p>
 
               {/* Primary value and unit */}
-              <span className="d-flex flex-row align-items-end">
+              <span className="d-flex flex-row flex-wrap align-items-end">
                 <h1 className="mb-0">{cardData.primary}</h1>
                 <p className="text-black-65 ms-1 m-0">{cardData.primaryUnit}</p>
               </span>


### PR DESCRIPTION
@cgalvarino 

While messing with the tab menu on station pages I noticed that a barometric pressure of 1013.5 with the unit of "Millibars" overflows the `latestObsCard`. Added wrapping to the container and seems to work okay. 

Unfortunately, this is on Dev currently so it'd be great to move this PR along if possible.

**Before**
<img width="186" height="245" alt="Screenshot 2026-05-25 at 8 04 32 PM" src="https://github.com/user-attachments/assets/88faa78c-e343-4e4f-8d50-095f3fcdb335" />

**After**
<img width="176" height="245" alt="Screenshot 2026-05-25 at 8 02 10 PM" src="https://github.com/user-attachments/assets/2be4fdc4-a2c4-4fb3-bc69-3559384a69d8" />
