### PR TITLE
Mid station details page tabs

### DIFF
--- a/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
@@ -33,7 +33,7 @@ export function PlatformTabs() {
 
             <Navbar.Collapse>
               <Nav className="w-100 mid-page-nav">
-                <Tab to={paths.platforms.platform} path={path} name="Latest Conditions" id={platformId} />
+                <Tab to={paths.platforms.platform} path={path} name="Last 24 Hours" id={platformId} />
                 <ErddapObservedDropdown {...platform_props} />
                 <ForecastDropdown platformId={platformId} />
                 <ErddapMoreInfoDropdown {...platform_props} />

--- a/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
@@ -27,18 +27,14 @@ export function PlatformTabs() {
   return (
     <UsePlatform platformId={id}>
       {(platform_props) => (
-        <React.Fragment>
-          <Row className="pb-4 px-0">
-            <Col>
-              <Nav variant="tabs">
+        <div className="d-flex flex-row mb-4 rounded-pill bg-black bg-opacity-5 ">
+              <Nav variant="toggle" className="w-100">
                 <ErddapObservedDropdown {...platform_props} />
                 <Tab to={paths.platforms.platform} path={path} name="Latest Conditions" id={platformId} />
                 <ForecastDropdown platformId={platformId} />
                 <ErddapMoreInfoDropdown {...platform_props} />
               </Nav>
-            </Col>
-          </Row>
-        </React.Fragment>
+        </div>
       )}
     </UsePlatform>
   )

--- a/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link"
 import { useParams, usePathname } from "next/navigation"
 import * as React from "react"
-import { Dropdown, Navbar, Nav } from "react-bootstrap"
+import { Navbar, Nav, Button } from "react-bootstrap"
 
 import { paths } from "Shared/constants"
 import { urlPartReplacer } from "Shared/urlParams"
@@ -27,8 +27,13 @@ export function PlatformTabs() {
       {(platform_props) => (
         <div className="d-flex flex-row mb-4 bg-black bg-opacity-5 mid-page-nav-container">
           <Navbar collapseOnSelect expand="sm" className="w-100">
-            <Navbar.Toggle className="dropdown-toggle w-100">
-              <strong>Station Options</strong>
+            <Navbar.Toggle className="d-flex d-sm-none flex-row w-100 bg-info text-light align-items-center">
+              <span className="d-flex ">
+                <strong>Station Menu</strong>
+              </span>
+              <Button className="bg-white ms-auto">
+                <span className="navbar-toggler-icon " />
+              </Button>
             </Navbar.Toggle>
 
             <Navbar.Collapse>

--- a/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
@@ -2,9 +2,7 @@
 import Link from "next/link"
 import { useParams, usePathname } from "next/navigation"
 import * as React from "react"
-import Col from "react-bootstrap/Col"
-import Row from "react-bootstrap/Row"
-import Nav from "react-bootstrap/Nav"
+import { Dropdown, Navbar, Nav } from "react-bootstrap"
 
 import { paths } from "Shared/constants"
 import { urlPartReplacer } from "Shared/urlParams"
@@ -27,13 +25,21 @@ export function PlatformTabs() {
   return (
     <UsePlatform platformId={id}>
       {(platform_props) => (
-        <div className="d-flex flex-row mb-4 rounded-pill bg-black bg-opacity-5 ">
-              <Nav variant="toggle" className="w-100">
-                <ErddapObservedDropdown {...platform_props} />
+        <div className="d-flex flex-row mb-4 bg-black bg-opacity-5 mid-page-nav-container">
+          <Navbar collapseOnSelect expand="sm" className="w-100">
+            <Navbar.Toggle className="dropdown-toggle w-100">
+              <strong>Station Options</strong>
+            </Navbar.Toggle>
+
+            <Navbar.Collapse>
+              <Nav className="w-100 mid-page-nav">
                 <Tab to={paths.platforms.platform} path={path} name="Latest Conditions" id={platformId} />
+                <ErddapObservedDropdown {...platform_props} />
                 <ForecastDropdown platformId={platformId} />
                 <ErddapMoreInfoDropdown {...platform_props} />
               </Nav>
+            </Navbar.Collapse>
+          </Navbar>
         </div>
       )}
     </UsePlatform>
@@ -53,16 +59,12 @@ interface TabProps {
 // tslint:disable-next-line:max-classes-per-file
 function Tab(props: TabProps) {
   const { to, name, path, id } = props
+  const linkTarget = urlPartReplacer(to, ":id", id)
 
   return (
     <Nav.Item>
-      <Nav.Link
-        as={Link}
-        href={urlPartReplacer(to, ":id", id)}
-        className={to === path ? "nav-link active" : "nav-link"}
-        active={to === path}
-      >
-        {name}
+      <Nav.Link as={Link} href={linkTarget} className={`${linkTarget === path && "mid-page-nav-active text-white"}`}>
+        <strong>{name}</strong>
       </Nav.Link>
     </Nav.Item>
   )

--- a/src/Features/ERDDAP/ForecastsMetadata/Menu/index.tsx
+++ b/src/Features/ERDDAP/ForecastsMetadata/Menu/index.tsx
@@ -6,6 +6,7 @@ import * as React from "react"
 import Link from "next/link"
 import Dropdown from "react-bootstrap/Dropdown"
 import Nav from "react-bootstrap/Nav"
+import { usePathname } from "next/navigation"
 
 import { paths } from "Shared/constants"
 import { urlPartReplacer } from "Shared/urlParams"
@@ -56,6 +57,9 @@ interface BaseProps extends Props {
 //  * Dropdown menu with links to the available forecasts.
  */
 export function ForecastDropdownBase({ forecasts, platformId }: BaseProps) {
+  const path = usePathname()
+  const linkIsActive = path.startsWith(`/platform/${platformId}/forecast`)
+
   const forecastNames = Array.from(new Set(forecasts.map((forecast) => forecast.forecast_type)))
   forecastNames.sort()
 
@@ -75,8 +79,8 @@ export function ForecastDropdownBase({ forecasts, platformId }: BaseProps) {
 
   return (
     <Dropdown as={Nav.Item}>
-      <Dropdown.Toggle as={Nav.Link} id="forecast">
-        Forecasts
+      <Dropdown.Toggle as={Nav.Link} id="forecast" className={`${linkIsActive && "mid-page-nav-active text-white"}`}>
+        <strong>Forecasts</strong>
       </Dropdown.Toggle>
 
       <Dropdown.Menu>{forecastItems}</Dropdown.Menu>

--- a/src/Features/ERDDAP/ForecastsMetadata/Menu/index.tsx
+++ b/src/Features/ERDDAP/ForecastsMetadata/Menu/index.tsx
@@ -58,7 +58,7 @@ interface BaseProps extends Props {
  */
 export function ForecastDropdownBase({ forecasts, platformId }: BaseProps) {
   const path = usePathname()
-  const linkIsActive = path.startsWith(`/platform/${platformId}/forecast`)
+  const linkIsActive = path ? path.startsWith(`/platform/${platformId}/forecast`) : ""
 
   const forecastNames = Array.from(new Set(forecasts.map((forecast) => forecast.forecast_type)))
   forecastNames.sort()

--- a/src/Features/ERDDAP/Platform/MoreInfoMenu/index.tsx
+++ b/src/Features/ERDDAP/Platform/MoreInfoMenu/index.tsx
@@ -8,6 +8,7 @@ import type { Point } from "geojson"
 import { useEffect, useState } from "react"
 import Dropdown from "react-bootstrap/Dropdown"
 import Nav from "react-bootstrap/Nav"
+import { usePathname } from "next/navigation"
 
 import { UsePlatformRenderProps } from "../../hooks/BuoyBarnComponents"
 
@@ -48,7 +49,9 @@ export function ErddapMoreInfoDropdown({ platform }: UsePlatformRenderProps) {
 
   return (
     <Dropdown as={Nav.Item} role="menu">
-      <Dropdown.Toggle as={Nav.Link}>More info</Dropdown.Toggle>
+      <Dropdown.Toggle as={Nav.Link}>
+        <strong>More info</strong>
+      </Dropdown.Toggle>
 
       <Dropdown.Menu>
         {dynamicLinks}

--- a/src/Features/ERDDAP/Platform/Observations/Menu/index.spec.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Menu/index.spec.tsx
@@ -10,10 +10,10 @@ describe("ErddapObservedDropdown", () => {
   it("Renders a menu for a platform", async () => {
     render(<ErddapObservedDropdown platform={platform} />)
 
-    expect(screen.getByRole("menu")).toHaveTextContent("Observations")
+    expect(screen.getByRole("menu")).toHaveTextContent("All Data")
 
     const user = userEvent.setup()
-    await user.click(screen.getByText("Observations"))
+    await user.click(screen.getByText("All Data"))
 
     const items = screen.getAllByRole("menuitem")
 

--- a/src/Features/ERDDAP/Platform/Observations/Menu/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Menu/index.tsx
@@ -6,6 +6,7 @@ import * as React from "react"
 import Link from "next/link"
 import Dropdown from "react-bootstrap/Dropdown"
 import Nav from "react-bootstrap/Nav"
+import { usePathname } from "next/navigation"
 
 import { paths } from "Shared/constants"
 import { urlPartReplacer } from "Shared/urlParams"
@@ -39,6 +40,9 @@ export function ErddapObservedDropdown({ platform }: UsePlatformRenderProps) {
     )
   }
 
+  const path = usePathname()
+  const linkIsActive = path.startsWith(`/platform/${platform.id}/observations`)
+
   const dropdownItems = Array.from(
     new Set(
       platform.properties.readings
@@ -70,7 +74,9 @@ export function ErddapObservedDropdown({ platform }: UsePlatformRenderProps) {
 
   return (
     <Dropdown as={Nav.Item} role="menu">
-      <Dropdown.Toggle as={Nav.Link}>Observations</Dropdown.Toggle>
+      <Dropdown.Toggle as={Nav.Link} className={`${linkIsActive && "mid-page-nav-active text-white"}`}>
+        <strong>All Data</strong>
+      </Dropdown.Toggle>
 
       <Dropdown.Menu>
         <Link

--- a/src/Features/ERDDAP/Platform/Observations/Menu/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Menu/index.tsx
@@ -41,7 +41,7 @@ export function ErddapObservedDropdown({ platform }: UsePlatformRenderProps) {
   }
 
   const path = usePathname()
-  const linkIsActive = path.startsWith(`/platform/${platform.id}/observations`)
+  const linkIsActive = path ? path.startsWith(`/platform/${platform.id}/observations`) : ""
 
   const dropdownItems = Array.from(
     new Set(

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -40,7 +40,7 @@ function NavLink({ href, children }: { href: string; children: React.ReactNode }
 const NeracoosNavBar = () => {
   return (
     <div>
-      <Navbar data-bs-theme="dark" className="bg-primary mb-4 dark-nav-custom" expand="md">
+      <Navbar collapseOnSelect data-bs-theme="dark" className="bg-primary mb-4 dark-nav-custom" expand="md">
         <Container fluid className="mx-5 px-0">
           <Navbar.Brand href={paths.home}>
             <div className="d-flex flex-column flex-md-row align-items-md-center gap-2 gap-md-4">

--- a/src/components/TabPane/index.tsx
+++ b/src/components/TabPane/index.tsx
@@ -8,10 +8,10 @@ import Nav from "react-bootstrap/Nav"
  */
 export const ContentTab = ({ name, index, setOpen, active }) => {
   return (
-      <Nav.Item key={index} style={{ cursor: "pointer" }}>
-        <Nav.Link key={index} onClick={() => setOpen(index)} active={active}>
-          {name}
-        </Nav.Link>
-      </Nav.Item>
+    <Nav.Item key={index} style={{ cursor: "pointer" }}>
+      <Nav.Link key={index} onClick={() => setOpen(index)} active={active}>
+        {name}
+      </Nav.Link>
+    </Nav.Item>
   )
 }

--- a/src/components/TabPane/index.tsx
+++ b/src/components/TabPane/index.tsx
@@ -8,10 +8,10 @@ import Nav from "react-bootstrap/Nav"
  */
 export const ContentTab = ({ name, index, setOpen, active }) => {
   return (
-    <Nav.Item key={index} style={{ cursor: "pointer" }}>
-      <Nav.Link key={index} onClick={() => setOpen(index)} active={active}>
-        {name}
-      </Nav.Link>
-    </Nav.Item>
+      <Nav.Item key={index} style={{ cursor: "pointer" }}>
+        <Nav.Link key={index} onClick={() => setOpen(index)} active={active}>
+          {name}
+        </Nav.Link>
+      </Nav.Item>
   )
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -332,17 +332,17 @@ $dig-opacities: (
   color: $primary;
 }
 
-// @include media-breakpoint-up(xl){
-.mid-page-nav .nav-link:hover {
-  color: $black-65;
+@include media-breakpoint-up(xl){
+    .mid-page-nav .nav-link:hover {
+    color: $black-65;
+  }
 }
-// }
 
 .mid-page-nav-active {
   background-color: $primary;
   border-radius: 50rem;
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(sm){
     border-radius: 8px;
     margin-top: 4px;
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -330,6 +330,7 @@ $dig-opacities: (
 
 .mid-page-nav .nav-link {
   color: $primary;
+  padding-left: 1rem;
 }
 
 @include media-breakpoint-up(xl) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -318,6 +318,36 @@ $dig-opacities: (
   padding: 0px 10px 20px;
 }
 
+.mid-page-nav-container {
+  border-radius: 8px;
+  justify-content: center;
+
+  @include media-breakpoint-up(sm) {
+    border-radius: 50rem;
+    justify-content: baseline;
+  }
+}
+
+.mid-page-nav .nav-link {
+  color: $primary;
+}
+
+// @include media-breakpoint-up(xl){
+.mid-page-nav .nav-link:hover {
+  color: $black-65;
+}
+// }
+
+.mid-page-nav-active {
+  background-color: $primary;
+  border-radius: 50rem;
+
+  @include media-breakpoint-down(sm) {
+    border-radius: 8px;
+    margin-top: 4px;
+  }
+}
+
 // ==== GENERAL STATION DETAILS END ====
 .superlatives-tooltip .tooltip-inner {
   max-width: none;

--- a/src/index.scss
+++ b/src/index.scss
@@ -332,17 +332,22 @@ $dig-opacities: (
   color: $primary;
 }
 
-@include media-breakpoint-up(xl){
-    .mid-page-nav .nav-link:hover {
+@include media-breakpoint-up(xl) {
+  .mid-page-nav .nav-link:hover {
     color: $black-65;
   }
+}
+
+.mid-page-nav .dropdown-menu .dropdown-item:active {
+  background-color: transparent;
+  color: inherit;
 }
 
 .mid-page-nav-active {
   background-color: $primary;
   border-radius: 50rem;
 
-  @include media-breakpoint-down(sm){
+  @include media-breakpoint-down(sm) {
     border-radius: 8px;
     margin-top: 4px;
   }

--- a/tests/e2e/Platform/44007.spec.ts
+++ b/tests/e2e/Platform/44007.spec.ts
@@ -35,7 +35,7 @@ test.describe("Platfrom 44007", () => {
   test("Shows wind plot", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page.getByRole("menuitem", { name: "Wind" }).first().click()
@@ -122,7 +122,7 @@ test.describe("Platfrom 44007", () => {
   test.skip("Updated recently", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page
@@ -145,7 +145,7 @@ test.describe("Platfrom 44007", () => {
   test("Can view all observations", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page
@@ -157,7 +157,7 @@ test.describe("Platfrom 44007", () => {
   test("Can perisist observation view on hard refresh", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page

--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -60,7 +60,7 @@ test.describe("Platform A01", () => {
   test("Shows wind plot", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page.getByRole("menuitem", { name: "Wind" }).first().click()
@@ -142,7 +142,7 @@ test.describe("Platform A01", () => {
   test("Updated recently", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page
@@ -162,7 +162,7 @@ test.describe("Platform A01", () => {
   test("Can view all observations", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page
@@ -175,7 +175,7 @@ test.describe("Platform A01", () => {
   test("Can perisist observation view on hard refresh", async ({ page }) => {
     await page.goto(platformUrl)
     await page
-      .getByText(/Observations/)
+      .getByText(/All Data/)
       .first()
       .click()
     await page


### PR DESCRIPTION
@cgalvarino 
#3875 -- Middle option in comments

Reskins the mid-page nav bar on station details/large graph pages. 
General notes:
- Adds a pill shaped background on large screen and just normal border rounding on mobile. 
- Adds a pill shaped NERACOOS blue background to the active link
- Bold typography

Couple things folks might be interested in discussing:
- Went for the suggested nested dropdown approach on mobile to handle having multiple navigation options. Like it or no?
- Dropdown button string? "Station Options" was my best guess.

**Desktop**
<img width="1440" height="813" alt="Screenshot 2026-05-25 at 9 06 14 PM" src="https://github.com/user-attachments/assets/aecb43d8-87c3-43ab-b24c-f61bcc376a70" />

**Mobile -- Portrait**
<img width="191" height="319" alt="Screenshot 2026-05-25 at 9 05 17 PM" src="https://github.com/user-attachments/assets/1c64bf0a-f930-47fd-a44f-dfa3c9d9e901" />
<img width="191" height="319" alt="Screenshot 2026-05-25 at 9 05 29 PM" src="https://github.com/user-attachments/assets/b553015e-aa5e-407a-8001-024855050ab7" />


**Mobile -- Landscape**
<img width="842" height="390" alt="Screenshot 2026-05-25 at 9 05 45 PM" src="https://github.com/user-attachments/assets/558d2403-e820-41f5-82a9-f4625510323d" />


**Goal**
<img width="1360" height="524" alt="Screenshot 2026-05-25 at 9 01 26 PM" src="https://github.com/user-attachments/assets/b12b7d3c-5ae8-42a9-a29a-6b0020ecd1dc" />
