### PR TITLE
Double button warning

### DIFF
--- a/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/tabs.tsx
@@ -31,9 +31,9 @@ export function PlatformTabs() {
               <span className="d-flex ">
                 <strong>Station Menu</strong>
               </span>
-              <Button className="bg-white ms-auto">
+              <div className="btn bg-white ms-auto">
                 <span className="navbar-toggler-icon " />
-              </Button>
+              </div>
             </Navbar.Toggle>
 
             <Navbar.Collapse>


### PR DESCRIPTION
Buttons cannot be nested without causing a React hydration error, so this converts the platform collapsed hamburger button into a div.

```
[browser] In HTML, <button> cannot be a descendant of <button>.
client-1  | This will cause a hydration error.
client-1  | 
client-1  |   ...
client-1  |     <InnerLayoutRouter url="/platform/E01" tree={[...]} params={{...}} cacheNode={{...}} segmentPath={[...]} ...>
client-1  |       <SegmentViewNode type="layout" pagePath="(platformM...">
client-1  |         <SegmentTrieNode>
client-1  |         <script>
client-1  |         <script>
client-1  |         <PlatformTabsLayout>
client-1  |           <DehydratedPlatforms>
client-1  |             <HydrationBoundary state={{...}}>
client-1  |               <PlatformTabs>
client-1  |                 <UsePlatform platformId="E01">
client-1  |                   <UsePlatforms loading={undefined} error={undefined}>
client-1  |                     <div className="d-flex fle...">
client-1  |                       <Navbar collapseOnSelect={true} expand="sm" className="w-100">
client-1  |                         <nav ref={null} className="w-100 navb...">
client-1  |                           <NavbarToggle className="d-flex d-s...">
client-1  | >                           <button
client-1  | >                             type="button"
client-1  | >                             ref={null}
client-1  | >                             onClick={function useEventCallback.useCallback}
client-1  | >                             aria-label="Toggle navigation"
client-1  | >                             className="d-flex d-sm-none flex-row w-100 bg-info text-light align-items-center navbar-..."
client-1  | >                           >
client-1  |                               <span>
client-1  |                               <Button className="bg-white m...">
client-1  | >                               <button
client-1  | >                                 type="button"
client-1  | >                                 disabled={false}
client-1  | >                                 ref={null}
client-1  | >                                 className="bg-white ms-auto btn btn-primary"
client-1  | >                               >
```