### PR TITLE
Stacked charts on wave page

### DIFF
--- a/app/(platformMap)/@bottom/platform/[platformId]/observations/waves/chart.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/observations/waves/chart.tsx
@@ -1,0 +1,12 @@
+"use client"
+import { ErddapWavesObservedCondition } from "Features/ERDDAP/Platform/Observations/WavesCondition"
+import { UsePlatform } from "Features/ERDDAP/hooks"
+import React from "react"
+
+export function WavesCharts({ platformId }: { platformId: string }) {
+  return (
+    <UsePlatform platformId={platformId}>
+      {({ platform }) => <ErddapWavesObservedCondition platform={platform} />}
+    </UsePlatform>
+  )
+}

--- a/app/(platformMap)/@bottom/platform/[platformId]/observations/waves/page.tsx
+++ b/app/(platformMap)/@bottom/platform/[platformId]/observations/waves/page.tsx
@@ -1,0 +1,16 @@
+import { DehydratedPlatforms } from "Features/ERDDAP/hooks/DehydrateComponent"
+
+import { WavesCharts } from "./chart"
+import React from "react"
+
+export default async function WavePlots(props: { params: Promise<{ platformId: string }> }) {
+  const params = await props.params
+
+  const { platformId } = params
+
+  return (
+    <DehydratedPlatforms>
+      <WavesCharts platformId={platformId} />
+    </DehydratedPlatforms>
+  )
+}

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -18,6 +18,7 @@ import { UseDataset } from "../../../hooks"
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
 import { Info } from "./Info"
 import { getStartFunction, Timeframes } from "Features/ERDDAP/TimeframeButtonGroup/timeframes"
+import { read } from "node:fs"
 
 interface Props {
   /** Platform to display */
@@ -49,9 +50,14 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
   const handleStartChoice = (start: Date) => setStartDate(start)
   const handleEndChoice = (end: Date) => setEndDate(end)
 
-  const timeSeries: PlatformTimeSeries[] = platform.properties.readings.filter(
-    (reading) => reading.data_type.standard_name === standardName,
-  )
+  // Special case to handle grouped wave latest obs card
+  const timeSeries: PlatformTimeSeries[] =
+    standardName === "waves"
+      ? platform.properties.readings.filter((reading) => reading.data_type.long_name.match("Wave"))
+      : platform.properties.readings.filter((reading) => reading.data_type.standard_name === standardName)
+
+  console.log(standardName)
+  console.log(platform.properties.readings)
   timeSeries.sort((a, b) => (a.depth && b.depth ? a.depth - b.depth : 0))
 
   const charts = timeSeries.map((ts: PlatformTimeSeries, index) => {

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -49,7 +49,6 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
   const handleStartChoice = (start: Date) => setStartDate(start)
   const handleEndChoice = (end: Date) => setEndDate(end)
 
-  // Special case to handle grouped wave latest obs card
   const timeSeries: PlatformTimeSeries[] = platform.properties.readings.filter(
     (reading) => reading.data_type.standard_name === standardName,
   )

--- a/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/Condition/index.tsx
@@ -56,8 +56,6 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
       ? platform.properties.readings.filter((reading) => reading.data_type.long_name.match("Wave"))
       : platform.properties.readings.filter((reading) => reading.data_type.standard_name === standardName)
 
-  console.log(standardName)
-  console.log(platform.properties.readings)
   timeSeries.sort((a, b) => (a.depth && b.depth ? a.depth - b.depth : 0))
 
   const charts = timeSeries.map((ts: PlatformTimeSeries, index) => {

--- a/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/LatestObsCards/LatestObsCard.tsx
@@ -37,7 +37,7 @@ export const LatestObsCard = ({ unitSystem, timeSeries, platform }: CardDisplayP
   const linkTarget = urlPartReplacer(
     urlPartReplacer(paths.platforms.observations, ":id", platform.id as string),
     ":type",
-    groupName === "Wind" ? groupName.toLowerCase() : firstTs.data_type.standard_name,
+    groupName === "Wind" || groupName === "Waves" ? groupName.toLowerCase() : firstTs.data_type.standard_name,
   )
 
   const cardData = Array.isArray(timeSeries)

--- a/src/Features/ERDDAP/Platform/Observations/WavesCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WavesCondition/index.tsx
@@ -16,7 +16,7 @@ import { aWeekAgoRounded, daysInFuture } from "Shared/time"
 
 import { UseDataset } from "../../../hooks"
 import { PlatformFeature, PlatformTimeSeries } from "../../../types"
-import { Info } from "./Info"
+import { Info } from "../Condition/Info"
 import { getStartFunction, Timeframes } from "Features/ERDDAP/TimeframeButtonGroup/timeframes"
 
 interface Props {
@@ -31,7 +31,7 @@ interface Props {
  * @param platform
  * @param standardName
  */
-export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platform, standardName }: Props) => {
+export const ErddapWavesObservedCondition: React.FunctionComponent<Props> = ({ platform, standardName }: Props) => {
   const unitSystem = useUnitSystem()
   const [startDate, setStartDate] = useState(aWeekAgoRounded())
   const [endDate, setEndDate] = useState(daysInFuture(0))
@@ -49,9 +49,8 @@ export const ErddapObservedCondition: React.FunctionComponent<Props> = ({ platfo
   const handleStartChoice = (start: Date) => setStartDate(start)
   const handleEndChoice = (end: Date) => setEndDate(end)
 
-  // Special case to handle grouped wave latest obs card
-  const timeSeries: PlatformTimeSeries[] = platform.properties.readings.filter(
-    (reading) => reading.data_type.standard_name === standardName,
+  const timeSeries: PlatformTimeSeries[] = platform.properties.readings.filter((reading) =>
+    reading.data_type.long_name.match("Wave"),
   )
 
   timeSeries.sort((a, b) => (a.depth && b.depth ? a.depth - b.depth : 0))

--- a/src/Features/ERDDAP/Platform/Observations/WavesCondition/index.tsx
+++ b/src/Features/ERDDAP/Platform/Observations/WavesCondition/index.tsx
@@ -22,16 +22,13 @@ import { getStartFunction, Timeframes } from "Features/ERDDAP/TimeframeButtonGro
 interface Props {
   /** Platform to display */
   platform: PlatformFeature
-  /** Standard name to display */
-  standardName: string
 }
 
 /**
  *
  * @param platform
- * @param standardName
  */
-export const ErddapWavesObservedCondition: React.FunctionComponent<Props> = ({ platform, standardName }: Props) => {
+export const ErddapWavesObservedCondition: React.FunctionComponent<Props> = ({ platform }: Props) => {
   const unitSystem = useUnitSystem()
   const [startDate, setStartDate] = useState(aWeekAgoRounded())
   const [endDate, setEndDate] = useState(daysInFuture(0))
@@ -57,6 +54,8 @@ export const ErddapWavesObservedCondition: React.FunctionComponent<Props> = ({ p
 
   const charts = timeSeries.map((ts: PlatformTimeSeries, index) => {
     const depth = ts.depth && ts.depth > 0 ? " at " + ts.depth + "m below" : ""
+
+    const name = ts.data_type.standard_name
 
     return (
       <div key={ts.depth ? ts.depth : index} className="d-flex flex-column gap-2">
@@ -105,7 +104,7 @@ export const ErddapWavesObservedCondition: React.FunctionComponent<Props> = ({ p
         >
           {({ dataset }) => (
             <ChartTimeSeriesDisplay
-              {...{ dataset, standardName, unitSystem }}
+              {...{ dataset, standardName: name, unitSystem }}
               timeSeries={ts}
               startTime={startDate}
               endTime={endDate}


### PR DESCRIPTION
@cgalvarino 

When a user clicks on the grouped latest obs wave card, they're taken to `observations/waves` which shows all wave related conditions charts from the station.

Didn't implement this sort of grouping for when someone clicks on the small chart cards on a station. Can definitely add that in though!

Tough to get good screenshots of this behavior.
<img width="1440" height="814" alt="Screenshot 2026-06-01 at 9 20 08 AM" src="https://github.com/user-attachments/assets/ecd017fe-2205-4c84-af41-406b2b6e2741" />

<img width="297" height="650" alt="Screenshot 2026-06-01 at 9 19 39 AM" src="https://github.com/user-attachments/assets/cfe37920-70ec-4f30-aa10-4e519fd2bfd7" />


