### PR TITLE
ODP Releaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,3 +80,12 @@ updates:
       time: "10:00"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: daily
+      time: "10:00"
+    cooldown:
+      default-days: 7

--- a/.github/deploy_targets.yaml
+++ b/.github/deploy_targets.yaml
@@ -1,0 +1,2 @@
+- owner: gulfofmaine
+  repo: neracoos-aws-cd

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: "Features"
+      labels:
+        - "feature"
+    - title: "Bug Fixes"
+      labels:
+        - "bug"
+    - title: "Other Changes"
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - "dependencies"
+    - title: "Dependency Updates"
+      labels:
+        - "dependencies"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,10 +14,20 @@ on:
   schedule:
     - cron: "0 22 * * 2"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF results
+      actions: read # required for private repos to read CodeQL bundle location
 
     strategy:
       fail-fast: false
@@ -30,11 +40,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
+          persist-credentials: false
 
       # If this run was triggered by a pull request event, then checkout
       # the head of the pull request instead of the merge commit.
@@ -43,7 +54,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +65,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.36.3
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +79,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,12 +3,23 @@ name: pre-commit
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   pre-commit:
+    name: pre-commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.9"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   pre-commit:
-    name: pre-commit
+    name: pre-commit (prek)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,7 +19,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.9"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,28 +13,34 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
     name: Build and cache Docker image
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         continue-on-error: true
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: dev
@@ -45,7 +51,7 @@ jobs:
           outputs: type=docker,dest=/tmp/myimage.tar
 
       - name: Upload dev image artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dev-image
           path: /tmp/myimage.tar
@@ -56,16 +62,20 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Download dev image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dev-image
           path: /tmp
@@ -76,7 +86,7 @@ jobs:
           docker image ls -a
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: runner
@@ -87,7 +97,7 @@ jobs:
           outputs: type=docker,dest=/tmp/prodimage.tar
 
       - name: Upload production image artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: prod-image
           path: /tmp/prodimage.tar
@@ -97,17 +107,21 @@ jobs:
     name: Unit tests, typecheck and coverage
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: mise action
-        uses: jdx/mise-action@v4.1.0
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
           cache-name: cache-node-modules
         with:
@@ -133,7 +147,7 @@ jobs:
 
       - name: Codacy Coverage Reporter
         if: env.CODACY_PROJECT_TOKEN != null
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ./coverage/lcov.info
@@ -166,6 +180,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build-prod
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     env:
       # Playwright uses this env var for the browser install path. See:
@@ -175,15 +191,17 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: npm
 
       - name: Download production image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: prod-image
           path: /tmp
@@ -206,7 +224,7 @@ jobs:
         id: playwright-version
 
       # Cache action
-      - uses: actions/cache@v6.1.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: playwright-cache
         with:
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
@@ -223,7 +241,7 @@ jobs:
       - name: Run Playwright tests
         run: npm run test:e2e
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: playwright-report
@@ -267,16 +285,20 @@ jobs:
     if: |
       github.repository == 'gulfofmaine/Neracoos-1-Buoy-App'
       && github.event_name == 'release'
+    permissions:
+      contents: read
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Download production image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: prod-image
           path: /tmp
@@ -287,17 +309,19 @@ jobs:
           docker image ls -a
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Get tag name
         id: tagName
-        run: echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        run: echo "tag=${GITHUB_EVENT_RELEASE_TAG_NAME}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Build and push Docker Image
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: push
         with:
           context: .
@@ -312,7 +336,7 @@ jobs:
         run: docker run -v $PWD:/opt/mount --rm --entrypoint cp gmri/neracoos-mariners-dashboard -r /app/.next /opt/mount/next-build
 
       - name: Create Sentry Release
-        uses: getsentry/action-release@v3.7.0
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -356,16 +380,20 @@ jobs:
     if: |
       github.repository == 'gulfofmaine/Neracoos-1-Buoy-App'
       && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Download production image artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: prod-image
           path: /tmp
@@ -376,7 +404,7 @@ jobs:
           docker image ls -a
 
       - name: "Login to Docker Hub"
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -386,7 +414,7 @@ jobs:
         run: echo "tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker Image
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: push
         with:
           context: .
@@ -397,29 +425,11 @@ jobs:
             NEXT_PUBLIC_ERDDAP_SERVICE=https://buoybarn.neracoos.org
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN_DEV }}
 
-      - name: Make GitOps directory
-        run: mkdir gitops
-
-      - name: Clone GitOps config repo
-        run: git clone "https://$GITOPS_TOKEN@github.com/gulfofmaine/neracoos-aws-cd.git"
-        working-directory: ./gitops
-        env:
-          GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
-
-      - name: Update GitOps config repo
-        working-directory: ./gitops/neracoos-aws-cd
-        run: |
-          sed -i 's/?ref=.\+/?ref=${{ github.sha }}/' overlays/mariners-dev/kustomization.yaml
-          sed -i 's/newTag: .\+/newTag: "${{ steps.tagName.outputs.tag }}"/' overlays/mariners-dev/kustomization.yaml
-          git config --global user.email 'neracoos-mariners-ci@gmri.org'
-          git config --global user.name 'NERACOOS Mariners Dashboard CI'
-          git diff --exit-code && echo 'Already Deployed' || (git commit -am 'Upgrade Mariners Dashboard dev deployment to ${{ steps.tagName.outputs.tag }}' && git push)
-
       - name: Copy Next.JS sourcemaps
         run: docker run -v $PWD:/opt/mount --rm --entrypoint cp gmri/neracoos-mariners-dashboard -r /app/.next /opt/mount/next-build
 
       - name: Create Sentry Release
-        uses: getsentry/action-release@v3.7.0
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -261,6 +261,9 @@ jobs:
     needs: [unit_tests, playwright]
     timeout-minutes: 20
     environment: Deploy with ArgoCD
+    outputs:
+      tag: ${{ steps.tagName.outputs.tag }}
+      image_digest: ${{ steps.push.outputs.digest }}
     if: |
       github.repository == 'gulfofmaine/Neracoos-1-Buoy-App'
       && github.event_name == 'release'
@@ -295,6 +298,7 @@ jobs:
 
       - name: Build and push Docker Image
         uses: docker/build-push-action@v7.3.0
+        id: push
         with:
           context: .
           push: true
@@ -303,24 +307,6 @@ jobs:
           build-args: |
             NEXT_PUBLIC_ERDDAP_SERVICE=https://buoybarn.neracoos.org
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN_PROD }}
-
-      - name: Make GitOps directory
-        run: mkdir gitops
-
-      - name: Clone GitOps config repo
-        run: git clone "https://$GITOPS_TOKEN@github.com/gulfofmaine/neracoos-aws-cd.git"
-        working-directory: ./gitops
-        env:
-          GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
-
-      - name: Update GitOps config repo
-        working-directory: ./gitops/neracoos-aws-cd
-        run: |
-          sed -i 's/?ref=.\+/?ref=${{ steps.tagName.outputs.tag }}/' overlays/mariners/kustomization.yaml
-          sed -i 's/newTag: .\+/newTag: ${{ steps.tagName.outputs.tag }}/' overlays/mariners/kustomization.yaml
-          git config --global user.email 'neracoos-mariners-ci@gmri.org'
-          git config --global user.name 'NERACOOS Mariners Dashboard CI'
-          git diff --exit-code && echo 'Already Deployed' || (git commit -am 'Upgrade Mariners Dashboard to ${{ steps.tagName.outputs.tag }}' && git push)
 
       - name: Copy Next.JS sourcemaps
         run: docker run -v $PWD:/opt/mount --rm --entrypoint cp gmri/neracoos-mariners-dashboard -r /app/.next /opt/mount/next-build
@@ -337,12 +323,36 @@ jobs:
           sourcemaps: ./next-build
           inject: false
 
+  release:
+    name: Notify deploy repo of new release
+    needs: [push_image]
+    uses: gulfofmaine/odp-releaser/.github/workflows/notify.yml@52b11709c1fb73c142b24b62ce7a11ecb37f7da3
+    permissions:
+      contents: read
+      pull-requests: read # ODP Releaser wants to figure out who made a PR
+    if: |
+      github.repository == 'gulfofmaine/Neracoos-1-Buoy-App'
+      && github.event_name == 'release'
+    with:
+      image_name: gmri/neracoos-mariners-dashboard
+      tag: ${{ needs.push_image.outputs.tag }}
+      digest: ${{ needs.push_image.outputs.image_digest }}
+      environment: notify # optional gate
+      # deploy_targets_path: .github/deploy_targets.yaml  # optional
+      verbosity: 3 # optional, default
+    secrets:
+      dispatch_app_id: ${{ secrets.GULFOFMAINE_ODP_DISPATCH_APP_ID }}
+      dispatch_app_private_key: ${{ secrets.GULFOFMAINE_ODP_DISPATCH_PRIVATE_KEY }}
+
   push_dev_image:
     name: Build and push dev image to Docker Hub
     runs-on: ubuntu-24.04
     needs: [unit_tests, playwright]
     timeout-minutes: 20
     environment: Deploy with ArgoCD
+    outputs:
+      tag: ${{ steps.tagName.outputs.tag }}
+      image_digest: ${{ steps.push.outputs.digest }}
     if: |
       github.repository == 'gulfofmaine/Neracoos-1-Buoy-App'
       && github.ref == 'refs/heads/main'
@@ -377,6 +387,7 @@ jobs:
 
       - name: Build and push Docker Image
         uses: docker/build-push-action@v7.3.0
+        id: push
         with:
           context: .
           push: true
@@ -418,3 +429,24 @@ jobs:
           release: ${{ steps.tagName.outputs.tag }}
           sourcemaps: ./next-build
           inject: false
+
+  release_dev:
+    name: Notify deploy repo of new dev
+    needs: [push_dev_image]
+    uses: gulfofmaine/odp-releaser/.github/workflows/notify.yml@52b11709c1fb73c142b24b62ce7a11ecb37f7da3
+    permissions:
+      contents: read
+      pull-requests: read # ODP Releaser wants to figure out who made a PR
+    if: |
+      github.repository == 'gulfofmaine/Neracoos-1-Buoy-App'
+      && github.ref == 'refs/heads/main'
+    with:
+      image_name: gmri/neracoos-mariners-dashboard
+      tag: ${{ needs.push_dev_image.outputs.tag }}
+      digest: ${{ needs.push_dev_image.outputs.image_digest }}
+      environment: notify # optional gate
+      # deploy_targets_path: .github/deploy_targets.yaml  # optional
+      verbosity: 3 # optional, default
+    secrets:
+      dispatch_app_id: ${{ secrets.GULFOFMAINE_ODP_DISPATCH_APP_ID }}
+      dispatch_app_private_key: ${{ secrets.GULFOFMAINE_ODP_DISPATCH_PRIVATE_KEY }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
   pull_request:
+  release:
+    types:
+      - published
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -24,14 +25,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
-
-      - name: Cache Docker image
-        uses: actions/cache@v6.1.0
-        with:
-          path: /tmp/myimage.tar
-          key: mariners-dashboard-image-${{ github.sha }}
-          restore-keys: |
-            mariners-dashboard-image-
 
       - name: "Login to Docker Hub"
         uses: docker/login-action@v4.4.0
@@ -51,6 +44,13 @@ jobs:
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/myimage.tar
 
+      - name: Upload dev image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-image
+          path: /tmp/myimage.tar
+          retention-days: 1
+
   build-prod:
     name: Build production Docker image
     runs-on: ubuntu-24.04
@@ -64,21 +64,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 
-      - name: Cache Docker image
-        uses: actions/cache@v6.1.0
+      - name: Download dev image artifact
+        uses: actions/download-artifact@v7
         with:
-          path: /tmp/myimage.tar
-          key: mariners-dashboard-image-${{ github.sha }}
-          restore-keys: |
-            mariners-dashboard-image-
-
-      - name: Cache production Docker image
-        uses: actions/cache@v6.1.0
-        with:
-          path: /tmp/prodimage.tar
-          key: mariners-dashboard-prod-image-${{ github.sha }}
-          restore-keys: |
-            mariners-dashboard-prod-image-
+          name: dev-image
+          path: /tmp
 
       - name: Load Docker image
         run: |
@@ -95,6 +85,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/prodimage.tar
+
+      - name: Upload production image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: prod-image
+          path: /tmp/prodimage.tar
+          retention-days: 1
 
   unit_tests:
     name: Unit tests, typecheck and coverage
@@ -185,13 +182,11 @@ jobs:
           node-version: "22"
           cache: npm
 
-      - name: Cache Docker image
-        uses: actions/cache@v6.1.0
+      - name: Download production image artifact
+        uses: actions/download-artifact@v7
         with:
-          path: /tmp/prodimage.tar
-          key: mariners-dashboard-prod-image-${{ github.sha }}
-          restore-keys: |
-            mariners-dashboard-prod-image-
+          name: prod-image
+          path: /tmp
 
       - name: Load Docker image
         run: |
@@ -268,7 +263,7 @@ jobs:
     environment: Deploy with ArgoCD
     if: |
       github.repository == 'gulfofmaine/Neracoos-1-Buoy-App'
-      && contains(github.ref, 'refs/tags/v')
+      && github.event_name == 'release'
 
     steps:
       - name: "Checkout"
@@ -277,13 +272,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 
-      - name: Cache Docker image
-        uses: actions/cache@v6.1.0
+      - name: Download production image artifact
+        uses: actions/download-artifact@v7
         with:
-          path: /tmp/prodimage.tar
-          key: mariners-dashboard-prod-image-${{ github.sha }}
-          restore-keys: |
-            mariners-dashboard-prod-image-
+          name: prod-image
+          path: /tmp
 
       - name: Load Docker image
         run: |
@@ -297,8 +290,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Get tag name
-        uses: olegtarasov/get-tag@v2.1
         id: tagName
+        run: echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker Image
         uses: docker/build-push-action@v7.3.0
@@ -306,7 +299,7 @@ jobs:
           context: .
           push: true
           tags: gmri/neracoos-mariners-dashboard:${{ steps.tagName.outputs.tag }}
-          cache-from: type=local,src=/tmp/.buildx-cache
+          no-cache: true
           build-args: |
             NEXT_PUBLIC_ERDDAP_SERVICE=https://buoybarn.neracoos.org
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN_PROD }}
@@ -361,13 +354,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.1.0
 
-      - name: Cache Docker image
-        uses: actions/cache@v6.1.0
+      - name: Download production image artifact
+        uses: actions/download-artifact@v7
         with:
-          path: /tmp/prodimage.tar
-          key: mariners-dashboard-prod-image-${{ github.sha }}
-          restore-keys: |
-            mariners-dashboard-prod-image-
+          name: prod-image
+          path: /tmp
 
       - name: Load Docker image
         run: |

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,10 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # jdx/mise-action, actions/cache, and actions/setup-node caches in push.yml
+      # are low-confidence findings: these jobs only run trusted, non-forked
+      # push/main/release events and always run `npm install --frozen-lockfile`
+      # regardless of cache state, so a poisoned cache can't smuggle in
+      # unreviewed dependencies. Disabling caching entirely would remove real
+      # CI speedups for a low-severity, low-confidence risk.
+      - push.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: "src/stories/__snapshots__/storyshots.spec.ts.snap"
@@ -18,6 +18,16 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.3.3"
+    rev: "39e2973981e6d2f9b6c543b0086a2d2393abdc89" # frozen: v3.9.4
     hooks:
       - id: prettier
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # frozen: v1.26.1
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]
+
+update:
+  cooldown_days: 7


### PR DESCRIPTION
And other fun CI updates.

- Configures [ODP Releaser](https://gulfofmaine.github.io/odp-releaser/) for more secure deployment of images from `main` and on releases.
- Adds auto categorization of PRs for release note generation
- Securing of Actions workflows with Zizmor’s varieties of paranoia
- Converts the release jobs to actually run off published releases, than off of tags
- Uses artifacts to move images between jobs rather than cache