### PR TITLE
Switch Docker base image from Alpine to Debian slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 #syntax=docker/dockerfile:1.2
-FROM node:26.5.0-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS base
+FROM node:26.5.0-slim@sha256:715e55e4b84e4bb0ff48e49b398a848f08e55daed8eb6a0ea1839ae53bc57583 AS base
 
 # Install dependencies only when needed
 FROM base AS deps
 ARG NEXT_PUBLIC_SENTRY_DSN
 
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -46,8 +44,8 @@ ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN groupadd --system --gid 1001 nodejs
+RUN useradd --system --uid 1001 --gid nodejs nextjs
 
 COPY --from=builder /app/public ./public
 


### PR DESCRIPTION
Devcontainer tooling (git/gh/docker-outside-of-docker features, Playwright's
OS dependency installer) expects an apt-based distro; Alpine's musl/apk
environment isn't supported by most of it. Debian slim keeps a similar image
size while being broadly compatible.

Updates the production runner stage's user creation to Debian's
groupadd/useradd (Alpine's addgroup/adduser aren't available), and drops the
now-unnecessary libc6-compat package (Alpine-only, not needed on glibc-based
Debian).