### PR TITLE
Test Salinity instead of Sigma-T in A01 all observations

### DIFF
--- a/tests/e2e/Platform/a01.spec.ts
+++ b/tests/e2e/Platform/a01.spec.ts
@@ -168,7 +168,7 @@ test.describe("Platform A01", () => {
       .getByText(/All Observations/)
       .first()
       .click()
-    await expect(page.getByText(/Sigma-T/).first()).toBeVisible()
+    await expect(page.getByText(/Salinity/).first()).toBeVisible()
   })
 
   test("Can perisist observation view on hard refresh", async ({ page }) => {


### PR DESCRIPTION
## What

Change the `Platform A01 › Can view all observations` Playwright assertion from `Sigma-T` to `Salinity`.

```diff
-    await expect(page.getByText(/Sigma-T/).first()).toBeVisible()
+    await expect(page.getByText(/Salinity/).first()).toBeVisible()
```

## Why

This one test has been failing on every PR since ~Aug 12–13, and it is the **only** failing check — build, prod build, unit tests + typecheck, CodeQL, Codacy and pre-commit are all green. It has blocked the entire dependency queue (nothing has merged to `main` in ~12 days).

```
[chromium] › tests/e2e/Platform/a01.spec.ts:161:7 › Platform A01 › Can view all observations
[firefox]  › tests/e2e/Platform/a01.spec.ts:161:7 › Platform A01 › Can view all observations
  Error: expect(locator).toBeVisible() failed
  Locator: getByText(/Sigma-T/).first()
  Error: element(s) not found
```

The failure is not a dependency regression:

- The integration tests run the built production image with `NEXT_PUBLIC_ERDDAP_SERVICE=https://buoybarn.neracoos.org`, so they assert against **live** upstream data — an upstream dataset change breaks them with no code change.
- `Sigma-T` is the display label for the `sea_water_density` standard name (`src/Features/Units/Converter/data_types/index.ts:148`). When Buoy Barn stops serving a `sea_water_density` dataset for A01, that row disappears from All Observations and the locator matches nothing.
- The neighbouring `Updated recently` test still passes — it opens the same All Observations page and asserts data within 3 days. So the page renders and A01 data is current; only the Sigma-T entry is gone.
- Both browsers fail all three attempts (2 retries), so it is not a flake.
- PR #4343 is a four-line bump of a pinned action SHA touching only `.github/workflows/push.yml`, and it fails identically — it cannot affect what the app renders.

`Salinity` is the display label for `sea_water_salinity` (`src/Features/Units/Converter/data_types/index.ts:163`), which A01 still reports.

## Verification

- `npx prettier --check tests/e2e/Platform/a01.spec.ts` — passes (prettier is the pre-commit formatter)
- `npx tsc` — passes

The e2e test itself could not be run locally: this sandbox's network policy blocks `buoybarn.neracoos.org` and `mariners.neracoos.org`, so the app cannot fetch any data here. **This PR's own CI run is the verification** — the `Playwright integration tests` check going green confirms A01 still serves salinity. If it stays red on this assertion, salinity is gone from A01 too and a different variable is needed.

## Notes

- `tests/e2e/Platform/m01.spec.ts:151` asserts `Sigma-T @ 1m` the same way, but its entire `describe` block is already `test.describe.skip` (`m01.spec.ts:5`) — that is why only A01 surfaced. Left untouched deliberately: changing a disabled assertion cannot be validated by CI and would be unverified churn. Worth revisiting whenever M01 is re-enabled.
- The underlying design issue remains: the e2e suite gates every PR on live upstream data, so any Buoy Barn dataset change hard-blocks merges. Mocking the ERDDAP/Buoy Barn responses for the observation-list assertions would decouple the dependency queue from upstream availability. Out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QM9795jb2peYQdajkKmPDo)_